### PR TITLE
Fix 500s on /verify/{username}

### DIFF
--- a/backend/db.py
+++ b/backend/db.py
@@ -7,10 +7,14 @@ import aiosqlite as sql
 
 DATABASE_FILENAME = 'scratchverifier.db'
 USERS_API = 'https://api.scratch.mit.edu/users/{}'
+VERIFY_EXPIRY = 1800 # 30 minutes
+SESSION_EXPIRY = 31540000 # 1 year in seconds
 
 class Database:
     def __init__(self, session):
         loop = asyncio.get_event_loop()
+        # lock to prevent race conditions when SELECT then fetchone
+        self.lock = asyncio.Lock(loop=loop)
         self.dbw = loop.run_until_complete(sql.connect(DATABASE_FILENAME))
         self.dbw.row_factory = sql.Row
         self.db = loop.run_until_complete(self.dbw.cursor())
@@ -26,18 +30,20 @@ class Database:
     ### TABLE: clients ###
 
     async def client_matches(self, client_id, token):
-        await self.db.execute('SELECT client_id FROM scratchverifier_clients \
+        async with self.lock:
+            await self.db.execute('SELECT client_id FROM scratchverifier_clients \
 WHERE client_id=? AND token=?', (client_id, token))
-        if (await self.db.fetchone()):
-            return True
+            if (await self.db.fetchone()):
+                return True
         return False
 
     ### TABLE: clients and sessions ###
 
     async def username_from_session(self, session_id):
-        await self.db.execute('SELECT username FROM scratchverifier_sessions \
+        async with self.lock:
+            await self.db.execute('SELECT username FROM scratchverifier_sessions \
 WHERE session_id=?', (session_id,))
-        row = await self.db.fetchone()
+            row = await self.db.fetchone()
         if row is None:
             return None
         return row[0]
@@ -63,9 +69,10 @@ token, username) VALUES (?, ?, ?)', (client_id, token, username))
         username = await self.username_from_session(session_id)
         if username is None:
             return None
-        await self.db.execute('SELECT * FROM scratchverifier_clients \
+        async with self.lock:
+            await self.db.execute('SELECT * FROM scratchverifier_clients \
 WHERE username=?', (username,))
-        row = await self.db.fetchone()
+            row = await self.db.fetchone()
         if row is None:
             return None
         return dict(row)
@@ -93,14 +100,15 @@ WHERE username=?', (username,))
     async def new_session(self, username):
         while 1:
             session_id = randbits(32)
-            await self.db.execute('SELECT session_id FROM \
+            async with self.lock:
+                await self.db.execute('SELECT session_id FROM \
 scratchverifier_sessions WHERE session_id=?', (session_id,))
-            if (await self.db.fetchone()) is None:
-                break
+                if (await self.db.fetchone()) is None:
+                    break
         await self.db.execute('INSERT INTO scratchverifier_sessions \
 (session_id, expiry, username) VALUES (?, ?, ?)', (
             session_id,
-            int(time.time()) + 31540000, # 1 year in seconds
+            int(time.time()) + SESSION_EXPIRY,
             username
         ))
         await self.db.execute('DELETE FROM scratchverifier_sessions WHERE \
@@ -110,9 +118,10 @@ expiry<=?', (int(time.time()),))
     async def get_expired(self, session_id):
         if session_id == 0: # 0 means debug mode
             return False
-        await self.db.execute('SELECT expiry FROM scratchverifier_sessions \
+        async with self.lock:
+            await self.db.execute('SELECT expiry FROM scratchverifier_sessions \
 WHERE session_id=?', (session_id,))
-        expiry = await self.db.fetchone()
+            expiry = await self.db.fetchone()
         if expiry is None:
             return True
         expiry = expiry[0]
@@ -133,12 +142,13 @@ WHERE username=?', (username,))
     ### TABLE: usage ###
 
     async def start_verification(self, client_id, username):
-        await self.db.execute('SELECT code FROM scratchverifier_usage WHERE \
+        async with self.lock:
+            await self.db.execute('SELECT code FROM scratchverifier_usage WHERE \
 client_id=? AND username=?', (client_id, username))
-        row = await self.db.fetchone()
+            row = await self.db.fetchone()
         if row is not None:
             await self.db.execute('UPDATE scratchverifier_usage SET expiry=? \
-WHERE client_id=? AND username=? AND code=?', (int(time.time()) + 1800,
+WHERE client_id=? AND username=? AND code=?', (int(time.time()) + VERIFY_EXPIRY,
                                                client_id, username, row[0]))
             return row[0]
         code = sha256(
@@ -146,10 +156,11 @@ WHERE client_id=? AND username=? AND code=?', (int(time.time()) + 1800,
             + str(time.time()).encode()
             + username.encode()
             + token_bytes()
-        ).hexdigest().translate({48 + i: 65 + i for i in range(10)})
+        # 0->A, 1->B, etc, to avoid Scratch's phone number censor
+        ).hexdigest().translate({ord('0') + i: ord('A') + i for i in range(10)})
         await self.db.execute('INSERT INTO scratchverifier_usage (client_id, \
 code, username, expiry) VALUES (?, ?, ?, ?)', (client_id, code, username,
-                               int(time.time() + 1800)))
+                               int(time.time() + VERIFY_EXPIRY)))
         await self.db.execute('INSERT INTO scratchverifier_logs (client_id, \
 username, log_time, log_type) VALUES (?, ?, ?, ?)', (client_id, username,
                                                      int(time.time()), 1))
@@ -158,9 +169,10 @@ expiry<=?', (int(time.time()),))
         return code
 
     async def get_code(self, client_id, username):
-        await self.db.execute('SELECT code, expiry FROM scratchverifier_usage \
+        async with self.lock:
+            await self.db.execute('SELECT code, expiry FROM scratchverifier_usage \
 WHERE client_id=? AND username=?', (client_id, username))
-        row = await self.db.fetchone()
+            row = await self.db.fetchone()
         if row is None:
             return None
         if time.time() > row['expiry']:
@@ -198,14 +210,16 @@ VALUES (?, ?, ?, ?)', (client_id, username, int(time.time()), 3 - succ))
             if k in {'start', 'before', 'end', 'after', 'client_id', 'type'}:
                 params[k] = int(v)
         limit = int(limit)
-        await self.db.execute(query, {'limit': limit, **params})
-        rows = await self.db.fetchall()
+        async with self.lock:
+            await self.db.execute(query, {'limit': limit, **params})
+            rows = await self.db.fetchall()
         return [dict(i) for i in rows]
 
     async def get_log(self, log_id):
-        await self.db.execute('SELECT * FROM scratchverifier_logs \
+        async with self.lock:
+            await self.db.execute('SELECT * FROM scratchverifier_logs \
 WHERE log_id=?', (log_id,))
-        row = await self.db.fetchone()
+            row = await self.db.fetchone()
         if row is None:
             return None
         return dict(row)


### PR DESCRIPTION
Resolves #35

There was a race condition where:
1. get_code is called
2. client_matches is called
3. get_code SELECTs code, expiry
4. client_matches SELECTs client_id before get_code can call db.fetchone()
5. get_code calls db.fetchone() and is returned the results of the SELECT client_id
6. client_matches calls db.fetchone() and is returned a guaranteed None (side effect that causes no errors but
probably causes problems too)

Solution: Introduce a lock around all occurences of db.execute('SELECT...'); db.fetchone(). That alters the
condition:
1. get_code is called
2. client_matches is called
3. get_code acquires the lock, then SELECTs code, expiry
4. client_matches attempts to acquire lock, and blocks
5. get_code calls db.fetchone(), is returned the results of the SELECT code, expiry, and releases the lock
6. client_matches unblocks and does its own SELECT and fetchone

Miscellaneous:
* Introduce constants for expiry of verification codes and session IDs, instead of using a literal number.
* Document the mapping of 0->A, 1->B, etc