### PR TITLE
Admin tools

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -18,7 +18,7 @@ jobs:
         python3 -m pip install --upgrade pip
         pip3 install -r requirements.txt
         cd backend
-        echo '{"port":8888,"hook-secret":"","name":"","discord-hook":""}' > config.json
+        echo '{"port":8888,"hook-secret":"","name":"","discord-hook":"","admins":["Kenny2scratch"]}' > config.json
         python3 . --debug &
         sleep 3
         python3 ../tests.py

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -18,7 +18,7 @@ jobs:
         python3 -m pip install --upgrade pip
         pip3 install -r requirements.txt
         cd backend
-        echo '{"port":8888,"hook-secret":"","name":"","discord-hook":"","admins":["Kenny2scratch"]}' > config.json
+        echo '{"port":8888,"hook-secret":"","name":"","discord-hook":"","admins":["kenny2scratch"]}' > config.json
         python3 . --debug &
         sleep 3
         python3 ../tests.py

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-[![Banner](https://u.cubeupload.com/smileycreations15/V732dJ.png)](https://scratchverifier.github.io/ScratchVerifier/)
+[![Banner](https://u.cubeupload.com/smileycreations15/V732dJ.png)](https://scratchverifier.ddns.net:8888)
 
 # ScratchVerifier
 Verify Scratch accounts as genuine, for use in authorization or identification.
 
-## [Website](https://scratchverifier.github.io/ScratchVerifier/)
+## [Website](https://scratchverifier.ddns.net:8888)

--- a/backend/__main__.py
+++ b/backend/__main__.py
@@ -12,5 +12,6 @@ with open('config.json') as f:
 Server(
     config['hook-secret'],
     config['discord-hook'],
+    config['admins'],
     config.get('name', None)
 ).run_sync(config['port'], len(sys.argv) > 1 and sys.argv[1] == '--debug')

--- a/backend/db.py
+++ b/backend/db.py
@@ -286,6 +286,11 @@ WHERE username=?', (username,))
             row = await self.db.fetchone()
         if row is None:
             return None
+        if row['expiry'] is not None and row['expiry'] < time.time():
+            # ban has expired, delete it and return no ban
+            await self.db.execute('DELETE FROM scratchverifier_bans \
+WHERE username=?', (username,))
+            return None
         return row
 
     async def set_bans(self, data, performer):

--- a/backend/db.py
+++ b/backend/db.py
@@ -265,17 +265,18 @@ WHERE username=?', (username,))
         await self.db.executemany('INSERT OR REPLACE INTO \
 scratchverifier_ratelimits (username, ratelimit) \
 VALUES (:username, :ratelimit)', data)
-        await self.db.executemany(
-            'INSERT INTO scratchverifier_auditlogs \
-(username, time, type, data) VALUES \
-(:username, :time, :type, :data)',
-            ({
-                'username': performer,
-                'time': int(time.time()),
-                'type': 2, # ratelimit update
-                'data': json.dumps(i)
-            } for i in data)
-        )
+        if performer is not None:
+            await self.db.executemany(
+                'INSERT INTO scratchverifier_auditlogs \
+    (username, time, type, data) VALUES \
+    (:username, :time, :type, :data)',
+                ({
+                    'username': performer,
+                    'time': int(time.time()),
+                    'type': 2, # ratelimit update
+                    'data': json.dumps(i)
+                } for i in data)
+            )
 
     ### TABLE: bans ###
 

--- a/backend/db.py
+++ b/backend/db.py
@@ -41,6 +41,8 @@ WHERE client_id=? AND token=?', (client_id, token))
     ### TABLE: clients and sessions ###
 
     async def username_from_session(self, session_id):
+        if session_id == 0: # 0 means debug mode
+            return 'kenny2scratch'
         async with self.lock:
             await self.db.execute('SELECT username FROM scratchverifier_sessions \
 WHERE session_id=?', (session_id,))
@@ -53,7 +55,7 @@ WHERE session_id=?', (session_id,))
         if session_id == 0: # 0 means debug mode
             # don't create a client, because other funcs return a dummy one
             # when under debug mode
-            return {'client_id': 0, 'username': 'Kenny2scratch',
+            return {'client_id': 0, 'username': 'kenny2scratch',
                     'token': 'This client is newly created.'}
         username = await self.username_from_session(session_id)
         if username is None:
@@ -69,7 +71,7 @@ token, username) VALUES (?, ?, ?)', (client_id, token, username))
 
     async def get_client(self, session_id):
         if session_id == 0: # 0 means debug mode
-            return {'client_id': 0, 'username': 'Kenny2scratch',
+            return {'client_id': 0, 'username': 'kenny2scratch',
                     'token': 'This is an example token that can be censored.'}
         username = await self.username_from_session(session_id)
         if username is None:
@@ -84,7 +86,7 @@ WHERE username=?', (username,))
 
     async def get_client_info(self, client_id):
         if client_id == 0: # 0 means debug mode
-            return {'client_id': 0, 'username': 'Kenny2scratch',
+            return {'client_id': 0, 'username': 'kenny2scratch',
                     'token': 'This is an example token that can be censored.'}
         async with self.lock:
             await self.db.execute('SELECT * FROM scratchverifier_clients \
@@ -96,7 +98,7 @@ WHERE client_id=?', (client_id,))
 
     async def reset_token(self, session_id):
         if session_id == 0: # 0 means debug mode
-            return {'client_id': 0, 'username': 'Kenny2scratch',
+            return {'client_id': 0, 'username': 'kenny2scratch',
                     'token': 'Yes, the token was reset.'}
         username = await self.username_from_session(session_id)
         if username is None:

--- a/backend/responses.py
+++ b/backend/responses.py
@@ -1,3 +1,5 @@
+Null = type(None)
+
 class Response(type):
     def __new__(cls, name, bases, attrs):
         def __init__(self, **kwargs):
@@ -33,13 +35,13 @@ class Verification(metaclass=Response):
     code: str
     username: str
 
-class Session(metaclass=Response):
-    session: int
-
 class User(metaclass=Response):
     client_id: int
     token: str
     username: str
+
+class Admin(metaclass=Response):
+    admin: bool
 
 class Log(metaclass=Response):
     log_id: int
@@ -47,3 +49,31 @@ class Log(metaclass=Response):
     username: str
     log_time: int
     log_type: int
+
+class Ratelimit(metaclass=Response):
+    username: int
+    limit: int
+
+class PartialRatelimit(metaclass=Response):
+    limit: int
+
+class Ban(metaclass=Response):
+    username: str,
+    expiry: (int, Null)
+
+class PartialBan(metaclass=Response):
+    expiry: (int, Null)
+
+class AuditLog(metaclass=Response):
+    id: int
+    username: str
+    time: int
+    type: int
+    data: str
+
+class Client(metaclass=Response):
+    client_id: int
+    token: str
+    username: str
+    ratelimit: int
+    banned: bool

--- a/backend/responses.py
+++ b/backend/responses.py
@@ -1,3 +1,21 @@
+import re
+
+DEFAULT_PORT = 8888
+COMMENTS_API = 'https://scratch.mit.edu/site-api/comments/user/{}/\
+?page=1&salt={}'
+USERNAME_REGEX = re.compile('^[A-Za-z0-9_-]{3,20}$')
+COMMENTS_REGEX = re.compile(r"""<div id="comments-\d+" class="comment +" data-comment-id="\d+">.*?<div class="actions-wrap">.*?<div class="name">\s+<a href="/users/([_a-zA-Z0-9-]+)">\1</a>\s+</div>\s+<div class="content">(.*?)</div>""", re.S)
+LIMIT_PER_TIME = 60 # in seconds
+DEFAULT_LOG_LIMIT = 100 # how many log entries to show if limit is unspecified
+MAX_LOG_LIMIT = 500 # how many /usage logs are allowed to show at once
+DEFAULT_RATELIMIT = 30 # max requests per LIMIT_PER_TIME
+TOKEN_CENSOR_LEN = 8 # how many characters to show in admin-viewed tokens
+
+DATABASE_FILENAME = 'scratchverifier.db'
+USERS_API = 'https://api.scratch.mit.edu/users/{}'
+VERIFY_EXPIRY = 1800 # 30 minutes
+SESSION_EXPIRY = 31540000 # 1 year in seconds
+
 Null = type(None)
 
 class Response(type):
@@ -51,7 +69,7 @@ class Log(metaclass=Response):
     log_type: int
 
 class Ratelimit(metaclass=Response):
-    username: int
+    username: str
     ratelimit: int
 
 class PartialRatelimit(metaclass=Response):
@@ -75,5 +93,5 @@ class Client(metaclass=Response):
     client_id: int
     token: str
     username: str
-    ratelimit: int
+    ratelimit: (int, Null)
     banned: bool

--- a/backend/responses.py
+++ b/backend/responses.py
@@ -52,13 +52,13 @@ class Log(metaclass=Response):
 
 class Ratelimit(metaclass=Response):
     username: int
-    limit: int
+    ratelimit: int
 
 class PartialRatelimit(metaclass=Response):
-    limit: int
+    ratelimit: int
 
 class Ban(metaclass=Response):
-    username: str,
+    username: str
     expiry: (int, Null)
 
 class PartialBan(metaclass=Response):

--- a/backend/responses.py
+++ b/backend/responses.py
@@ -10,6 +10,7 @@ DEFAULT_LOG_LIMIT = 100 # how many log entries to show if limit is unspecified
 MAX_LOG_LIMIT = 500 # how many /usage logs are allowed to show at once
 DEFAULT_RATELIMIT = 30 # max requests per LIMIT_PER_TIME
 TOKEN_CENSOR_LEN = 8 # how many characters to show in admin-viewed tokens
+HEADER_FORMAT = 'left={}, resets={}, to={}'
 
 DATABASE_FILENAME = 'scratchverifier.db'
 USERS_API = 'https://api.scratch.mit.edu/users/{}'

--- a/backend/server.py
+++ b/backend/server.py
@@ -15,10 +15,11 @@ COMMENTS_API = 'https://scratch.mit.edu/site-api/comments/user/{}/\
 ?page=1&salt={}'
 USERNAME_REGEX = re.compile('^[A-Za-z0-9_-]{3,20}$')
 COMMENTS_REGEX = re.compile(r"""<div id="comments-\d+" class="comment +" data-comment-id="\d+">.*?<div class="actions-wrap">.*?<div class="name">\s+<a href="/users/([_a-zA-Z0-9-]+)">\1</a>\s+</div>\s+<div class="content">(.*?)</div>""", re.S)
-DEFAULT_RATELIMIT = 30
-TOKEN_CENSOR_LEN = 8
-DEFAULT_LOG_LIMIT = 100
-MAX_LOG_LIMIT = 500
+DEFAULT_RATELIMIT = 30 # max requests per LIMIT_PER_TIME
+LIMIT_PER_TIME = 60 # in seconds
+TOKEN_CENSOR_LEN = 8 # how many characters to show in admin-viewed tokens
+DEFAULT_LOG_LIMIT = 100 # how many log entries to show if limit is unspecified
+MAX_LOG_LIMIT = 500 # how many /usage logs are allowed to show at once
 
 class Server:
     def __init__(self, hook_secret, discord_hook, admins, name=None):

--- a/backend/server.py
+++ b/backend/server.py
@@ -7,7 +7,7 @@ import hmac
 import asyncio
 import mimetypes
 from aiohttp import web, ClientSession, BasicAuth
-from db import Database, USERS_API
+from db import Database, USERS_API, SESSION_EXPIRY
 from responses import *
 
 DEFAULT_PORT = 8888
@@ -15,9 +15,20 @@ COMMENTS_API = 'https://scratch.mit.edu/site-api/comments/user/{}/\
 ?page=1&salt={}'
 USERNAME_REGEX = re.compile('^[A-Za-z0-9_-]{3,20}$')
 COMMENTS_REGEX = re.compile(r"""<div id="comments-\d+" class="comment +" data-comment-id="\d+">.*?<div class="actions-wrap">.*?<div class="name">\s+<a href="/users/([_a-zA-Z0-9-]+)">\1</a>\s+</div>\s+<div class="content">(.*?)</div>""", re.S)
+DEFAULT_RATELIMIT = 30
+TOKEN_CENSOR_LEN = 8
+DEFAULT_LOG_LIMIT = 100
+MAX_LOG_LIMIT = 500
 
 class Server:
-    def __init__(self, hook_secret, discord_hook, name=None):
+    def __init__(self, hook_secret, discord_hook, admins, name=None):
+        """Initialize the Server.
+
+        ``hook_secret``: str - Secret for GitHub webhook
+        ``discord_hook``: str - Link for Discord error webhook
+        ``admins``: set()-able - collection of admin usernames
+        ``name``: str - name that appears in webhook messages
+        """
         self.app = web.Application(middlewares=[self.errors])
         self.app.add_routes([
             web.put('/verify/{username}', self.verify),
@@ -26,13 +37,25 @@ class Server:
             web.post('/users/{username}/login', self.login),
             web.post('/users/{username}/finish-login', self.finish_login),
             web.post('/users/{username}/logout', self.logout_user),
-            web.get('/session/{session}', self.get_user),
-            web.put('/session/{session}', self.put_user),
-            web.patch('/session/{session}', self.reset_token),
-            web.delete('/session/{session}', self.del_user),
-            web.post('/session/{session}/logout', self.logout),
+            web.get('/session', self.get_user),
+            web.put('/session', self.put_user),
+            web.patch('/session', self.reset_token),
+            web.delete('/session', self.del_user),
+            web.post('/session/logout', self.logout),
             web.get('/usage', self.logs),
             web.get('/usage/{logid}', self.log),
+            web.get('/admin/ratelimits', self.get_ratelimits),
+            web.get('/admin/ratelimits/{username}', self.get_ratelimit),
+            web.patch('/admin/ratelimits', self.set_ratelimits),
+            web.post('/admin/ratelimits/{username}', self.set_ratelimit),
+            web.get('/admin/bans', self.get_bans),
+            web.get('/admin/bans/{username}', self.get_ban),
+            web.patch('/admin/bans', self.ban_multiple),
+            web.post('/admin/bans/{username}', self.ban_single),
+            web.delete('/admin/bans/{username}', self.unban),
+            web.get('/admin/logs', self.admin_logs),
+            web.get('/admin/logs/{logid}', self.admin_log),
+            web.get('/admin/client/{clientid}', self.get_client),
             web.post('/webhook', self.gh_hook),
             web.get('/site/{path:.*}', self.file_handler),
             web.get('/site/', self.file_handler),
@@ -48,6 +71,7 @@ class Server:
         self.db = Database(self.session)
         self.hook_secret = hook_secret.encode()
         self.discord_hook = discord_hook
+        self.admins = set(admins)
         self.name = name
         self.debug = False
         self._debug = False
@@ -55,6 +79,13 @@ class Server:
 
     @web.middleware
     async def errors(self, request, handler):
+        """Log to stdout and log errors to stdout and Discord webhook.
+
+        ``request``: aiohttp.Request object
+        ``handler``: method of this class
+
+        Returns whatever the ``handler`` returns, or raises some exception.
+        """
         print('%s %s %s' % (
             time.strftime('%Y-%m-%dT%H:%M:%SZ'),
             request.method,
@@ -87,7 +118,14 @@ class Server:
             })
             raise
 
+    # methods related to running the server
+
     async def run(self, port=DEFAULT_PORT, debug=False):
+        """Coroutine to run the server.
+
+        ``port``: int - port number to listen on
+        ``debug``: bool - whether to allow /debug endpoints
+        """
         self.runner = web.AppRunner(self.app)
         self._debug = debug
         await self.runner.setup()
@@ -95,11 +133,16 @@ class Server:
         await site.start()
 
     async def stop(self):
+        """Coroutine to close the server."""
         await self.runner.cleanup()
         await self.session.close()
         await self.db.close()
 
     async def _wakeup(self):
+        """Background task to stop the server if any source files are modified.
+        Doubles as a task that allows Ctrl+C to properly interrupt the loop
+        on Windows systems.
+        """
         files = glob(os.path.join(os.path.dirname(__file__), '*.py'))
         files.append(os.path.join(os.path.dirname(__file__),
                                   'sql', 'startup.sql'))
@@ -114,6 +157,9 @@ class Server:
                 return
 
     def run_sync(self, port=DEFAULT_PORT, debug=False):
+        """Synchronous method to run the server
+        and close it upon KeyboardInterrupt.
+        """
         loop = asyncio.get_event_loop()
         try:
             loop.run_until_complete(self.run(port, debug))
@@ -123,7 +169,15 @@ class Server:
         finally:
             loop.run_until_complete(self.stop())
 
+    # methods related to checking values
+
     async def check_token(self, request):
+        """Check if a request's token authentication is valid. Raise 401 if not.
+
+        ``request``: aiohttp.Request object
+
+        Returns int: client ID
+        """
         if self.debug:
             return 0
         if 'Authorization' not in request.headers:
@@ -138,6 +192,13 @@ class Server:
         return client_id
 
     async def check_username(self, request):
+        """Check if a username is a valid and existent Scratch username.
+        Raise 400 or 404, respectively, if not
+
+        ``request``: aiohttp.Request object
+
+        Returns str: casefolded username
+        """
         username = request.match_info.get('username', '')
         if not re.match(USERNAME_REGEX, username):
             raise web.HTTPBadRequest()
@@ -148,7 +209,10 @@ class Server:
                 raise web.HTTPNotFound()
         return username.casefold()
 
+    # the business part of the API
+
     async def verify(self, request):
+        """PUT /verify/{username}"""
         client_id = await self.check_token(request)
         username = await self.check_username(request)
         code = await self.db.start_verification(client_id, username)
@@ -157,6 +221,13 @@ class Server:
         ).d())
 
     async def _verified(self, client_id, username):
+        """Handle the logic of actually verifying the user.
+
+        ``client_id``: int - client requesting verification
+        ``username``: str - user to verify
+
+        Returns bool: whether verification succeeded
+        """
         if self.debug_pass:
             await self.db.end_verification(client_id, username, True)
             return True
@@ -188,6 +259,7 @@ class Server:
         return True
 
     async def verified(self, request):
+        """POST /verify/{username}"""
         client_id = await self.check_token(request)
         username = await self.check_username(request)
         if await self._verified(client_id, username):
@@ -196,28 +268,39 @@ class Server:
             raise web.HTTPForbidden()
 
     async def unverify(self, request):
+        """DELETE /verify/{username}"""
         client_id = await self.check_token(request)
         username = await self.check_username(request)
         await self.db.end_verification(client_id, username, -1)
         raise web.HTTPNoContent()
 
+    # logging in to the website
+
     async def login(self, request):
+        """POST /users/{username}/login"""
         username = await self.check_username(request)
+        if (await self.get_ban(username)) is not None:
+            raise web.HTTPForbidden()
         code = await self.db.start_verification(0, username)
         return web.json_response(Verification(
             code=code, username=username
         ).d())
 
     async def finish_login(self, request):
+        """POST /users/{username}/finish-login"""
         username = await self.check_username(request)
         if await self._verified(0, username):
-            return web.json_response(Session(
-                session=await self.db.new_session(username)
+            response = web.json_response(Admin(
+                admin=username in self.admins
             ).d())
+            response.set_cookie('session', await self.db.new_session(username),
+                                max_age=SESSION_EXPIRY)
+            return response
         else:
             raise web.HTTPUnauthorized()
 
     async def logout_user(self, request):
+        """POST /users/{username}/logout"""
         session_id = await self.check_session(request)
         data = User(**(await self.db.get_client(session_id)))
         username = await self.check_username(request)
@@ -226,10 +309,15 @@ class Server:
         await self.db.logout_user(username)
 
     async def check_session(self, request):
+        """Check whether a session ID is valid. Raise 401 if not.
+
+        ``request``: aiohttp.Request object
+
+        Returns int: session ID
+        """
         if self.debug:
-            return int(request.match_info['session'])
-        session = request.match_info.get('session',
-                                         request.query.get('session', ''))
+            return int(request.cookies['session'])
+        session = request.cookies.get('session', '')
         if not (session or session.strip()):
             raise web.HTTPUnauthorized()
         try:
@@ -240,7 +328,10 @@ class Server:
             raise web.HTTPUnauthorized()
         return session_id
 
+    # manipulating API registration data
+
     async def get_user(self, request):
+        """GET /session"""
         session_id = await self.check_session(request)
         data = await self.db.get_client(session_id)
         if data is None:
@@ -248,6 +339,7 @@ class Server:
         return web.json_response(data)
 
     async def put_user(self, request):
+        """PUT /session"""
         session_id = await self.check_session(request)
         data = await self.db.get_client(session_id)
         if data is not None:
@@ -258,21 +350,27 @@ class Server:
         return web.json_response(data)
 
     async def reset_token(self, request):
+        """PATCH /session"""
         session_id = await self.check_session(request)
         await self.db.reset_token(session_id)
         return await self.get_user(request)
 
     async def del_user(self, request):
+        """DELETE /session"""
         session_id = await self.check_session(request)
         await self.db.del_client(session_id)
         raise web.HTTPNoContent()
 
     async def logout(self, request):
+        """POST /session/logout"""
         session_id = await self.check_session(request)
         await self.db.logout(session_id)
         raise web.HTTPNoContent()
 
-    async def logs(self, request):
+    # usage logs
+
+    async def logs(self, request, table='logs'):
+        """GET /usage"""
         params = {}
         for k in {'limit', 'start', 'end', 'before',
                   'after', 'client_id', 'type'}:
@@ -281,31 +379,197 @@ class Server:
                     params[k] = int(request.query[k])
                 except ValueError:
                     raise web.HTTPBadRequest() from None
+        if 'start' in params and 'end' in params \
+           and params['end'] < params['start']:
+            raise web.HTTPBadRequest()
+        if 'before' in params and 'after' in params \
+           and params['after'] < params['before']:
+            raise web.HTTPBadRequest()
         if 'username' in request.query:
             params['username'] = request.query['username']
-        if params.get('limit', 100) > 500:
+        params.setdefault('limit', DEFAULT_LOG_LIMIT)
+        if table == 'logs' and params['limit'] > MAX_LOG_LIMIT:
             raise web.HTTPForbidden()
-        return web.json_response(await self.db.get_logs(**params))
+        return web.json_response(await self.db.get_logs(table, **params))
 
-    async def log(self, request):
+    async def log(self, request, table='logs'):
+        """GET /usage/{logid}"""
         log_id = request.match_info.get('logid', None)
         try:
             log_id = int(log_id)
         except ValueError:
             raise web.HTTPNotFound() from None
-        data = await self.db.get_log(log_id)
+        data = await self.db.get_log(log_id, table=table)
         if data is None:
             raise web.HTTPNotFound()
         return web.json_response(data)
 
-    async def gh_hook(self, request):
-        if 'X-Hub-Signature' not in request.headers:
+    # admin panel
+
+    async def admin_session(self, request):
+        """Check if a session owner is an admin. Raise 401 if not.
+
+        ``request``: aiohttp.Request object
+
+        Returns (int, str): session ID and username
+        """
+        session_id = await self.check_session(request)
+        username = await self.db.username_from_session(session_id)
+        if username not in self.admins:
             raise web.HTTPUnauthorized()
+        return username
+
+    # ratelimit endpoints
+
+    def get_client_id(self, request, badifinvalid=False):
+        """Get the client ID from the request.
+        Raise 404 if non-integer client ID is passed (or not passed)
+        or 400 if ``badifinvalid`` is True
+
+        ``request``: aiohttp.Request object
+        ``badifinvalid``: bool - if True, invalid ID raises 400, not 404
+
+        Returns int: client ID
+        """
+        client_id = request.match_info.get('clientid', None)
+        try:
+            client_id = int(client_id)
+        except ValueError:
+            if badifnot:
+                raise web.HTTPBadRequest() from None
+            raise web.HTTPNotFound() from None
+        return client_id
+
+    async def get_ratelimits(self, request):
+        """GET /admin/ratelimits"""
+        await self.admin_session(request)
+        return web.json_response(await self.db.get_ratelimits())
+
+    async def get_ratelimit(self, request):
+        """GET /admin/ratelimits/{username}"""
+        await self.admin_session(request)
+        username = self.check_username(request)
+        row = await self.db.get_ratelimit(username) # entire row
+        if row is None:
+            raise web.HTTPNotFound()
+        return web.json_response(PartialRatelimit(
+            limit=row['limit']
+        ).d())
+
+    async def set_ratelimits(self, request):
+        """PATCH /admin/ratelimits"""
+        performer = await self.admin_session(request)
+        data = [i for i in await request.json()
+                if isinstance(i.get('username', None), str)
+                and USERNAME_REGEX.match(i['username'])
+                and isinstance(i.get('limit', None), int)
+                and i['limit'] > 0]
+        await self.db.set_ratelimits(data, performer)
+        raise web.HTTPNoContent()
+
+    async def set_ratelimit(self, request):
+        """POST /admin/ratelimits/{username}"""
+        performer = await self.admin_session(request)
+        username = self.check_username(request)
+        data = await request.json()
+        if not isinstance(data.get('limit', None), int) or data['limit'] <= 0:
+            raise web.HTTPBadRequest()
+        await self.db.set_ratelimits(
+            [{'username': username,
+              'limit': data['limit']}],
+            performer
+        )
+        raise web.HTTPNoContent()
+
+    # banned user endpoints
+
+    async def get_bans(self, request):
+        """GET /admin/bans"""
+        await self.admin_session(request)
+        return web.json_response(await self.db.get_bans())
+
+    async def get_ban(self, request):
+        """GET /admin/bans/{username}"""
+        await self.admin_session(request)
+        username = self.check_username(request)
+        row = await self.db.get_ban(username) # entire row
+        if row is None:
+            raise web.HTTPNotFound()
+        return web.json_response(PartialBan(
+            expiry=row['expiry']
+        ).d())
+
+    async def ban_multiple(self, request):
+        """PATCH /admin/bans"""
+        performer = await self.admin_session(request)
+        data = [i for i in await request.json()
+                if isinstance(i['username'], str)
+                and USERNAME_REGEX.match(i['username'])
+                and (isinstance(i['expiry'], int)
+                     and i['expiry'] > time.time()
+                     or i['expiry'] is None)]
+        await self.db.set_bans(data, performer)
+        raise web.HTTPNoContent()
+
+    async def ban_single(self, request):
+        """POST /admin/bans/{username}"""
+        performer = await self.admin_session(request)
+        username = self.check_username(request)
+        data = await request.json()
+        if not isinstance(data.get('expiry', ...), (int, type(None))) \
+           or isinstance(data['expiry'], int) and data['expiry'] <= time.time():
+            raise web.HTTPBadRequest()
+        await self.db.set_bans(
+            [{'username': username,
+              'expiry': data['expiry']}],
+            performer
+        )
+        raise web.HTTPNoContent()
+
+    async def unban(self, request):
+        """DELETE /admin/bans/{username}"""
+        performer = await self.admin_session(request)
+        username = self.check_username(request)
+        await self.db.del_ban(username, performer)
+        raise web.HTTPNoContent()
+
+    # admin audit logs
+
+    async def admin_logs(self, request):
+        """GET /admin/logs"""
+        await self.admin_session(request)
+        return await self.logs(request, 'auditlogs')
+
+    async def admin_log(self, request):
+        """GET /admin/logs/{logid}"""
+        await self.admin_session(request)
+        return await self.log(request, 'auditlogs')
+
+    # miscellaneous endpoints, some undocumented
+
+    async def get_client(self, request):
+        """GET /admin/client/{clientid}"""
+        await self.admin_session(request)
+        client_id = self.get_client_id(request)
+        client = self.db.get_client_info(client_id)
+        if client is None:
+            raise web.HTTPNotFound()
+        username = client['username']
+        client['token'] = client['token'][:TOKEN_CENSOR_LEN] \
+                          + '*' * (len(client['token']) - TOKEN_CENSOR_LEN)
+        client['ratelimit'] = await self.db.get_ratelimit(username)['limit']
+        client['banned'] = (await self.db.get_ban(username)) is not None
+        return web.json_response(client)
+
+    async def gh_hook(self, request):
+        """POST /webhook"""
+        if 'X-Hub-Signature' not in request.headers:
+            raise web.HTTPForbidden()
         algo, hash = request.headers['X-Hub-Signature'].split('=')
         digest = hmac.new(self.hook_secret, await request.read(), algo)
         digest = digest.hexdigest()
         if not hmac.compare_digest(digest, hash):
-            raise web.HTTPUnauthorized()
+            raise web.HTTPForbidden()
         data = await request.json()
         if data['ref'] != 'refs/heads/master':
             raise web.HTTPNoContent() #success, but no action
@@ -315,6 +579,7 @@ class Server:
         raise web.HTTPNoContent()
 
     async def set_debug(self, request):
+        """POST /debug/{dibool}"""
         if not self._debug:
             raise web.HTTPNotFound()
         val = int(request.match_info['dibool'])
@@ -358,12 +623,15 @@ class Server:
             raise web.HTTPNotFound()
 
     async def file_handler(self, request):
+        """GET /site, /site/, /site/{path}"""
         return await self._file_handler(request, 'public')
 
     async def docs_handler(self, request):
+        """GET /docs, /docs/, /docs/{path}"""
         return await self._file_handler(request, 'docs')
 
     async def redir_root(self, request):
+        """GET /"""
         raise web.HTTPMovedPermanently('/site')
 
     async def not_found(self, request):

--- a/backend/sql/startup.sql
+++ b/backend/sql/startup.sql
@@ -50,7 +50,7 @@ CREATE TABLE IF NOT EXISTS scratchverifier_bans (
 );
 CREATE TABLE IF NOT EXISTS scratchverifier_auditlogs (
   -- log ID to look up by
-  log_id integer PRIMARY KEY AUTOINCREMENT,
+  id integer PRIMARY KEY AUTOINCREMENT,
   -- performer of action
   username text,
   -- unix epoch time of log

--- a/backend/sql/startup.sql
+++ b/backend/sql/startup.sql
@@ -36,3 +36,27 @@ CREATE TABLE IF NOT EXISTS scratchverifier_logs (
   -- type of log: 1 for starting verification, 2 for successful, 3 for failed verification
   log_type integer
 );
+CREATE TABLE IF NOT EXISTS scratchverifier_ratelimits (
+  -- username being limited
+  username text PRIMARY KEY,
+  -- number of requests per minute allowed
+  limit integer
+);
+CREATE TABLE IF NOT EXISTS scratchverifier_bans (
+  -- username being banned
+  username text PRIMARY KEY,
+  -- when the ban expires
+  expiry integer
+);
+CREATE TABLE IF NOT EXISTS scratchverifier_auditlogs (
+  -- log ID to look up by
+  log_id integer PRIMARY KEY AUTOINCREMENT,
+  -- performer of action
+  username text,
+  -- unix epoch time of log
+  time integer,
+  -- type of action (1 is ban, 2 is ratelimit update)
+  type integer,
+  -- naive JSON string of action data
+  data text
+);

--- a/backend/sql/startup.sql
+++ b/backend/sql/startup.sql
@@ -40,7 +40,7 @@ CREATE TABLE IF NOT EXISTS scratchverifier_ratelimits (
   -- username being limited
   username text PRIMARY KEY,
   -- number of requests per minute allowed
-  limit integer
+  ratelimit integer
 );
 CREATE TABLE IF NOT EXISTS scratchverifier_bans (
   -- username being banned

--- a/config-example.js
+++ b/config-example.js
@@ -4,5 +4,6 @@
   "port":8888, // HTTP Server port. Required.
   "discord-hook":"https://discord.com/api/webhooks/xxxxxxxxxxx/xxxxxxxxxxx", // Discord error logging hook, leave empty to not log. Optional.
   "hook-secret":"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", // GitHub webhook secret, used for automatic deployment. Only use type application/json hooks, and only the `push` event.
-  "name":"ScratchVerifier" // Instance owner / ID. Included in the error message from the Discord webhook.
+  "name":"ScratchVerifier", // Instance owner / ID. Included in the error message from the Discord webhook.
+  "admins":["user1", "user2"] // People with access to the /admin API's and /site/admin features.
 }

--- a/config-example.js
+++ b/config-example.js
@@ -5,5 +5,5 @@
   "discord-hook":"https://discord.com/api/webhooks/xxxxxxxxxxx/xxxxxxxxxxx", // Discord error logging hook, leave empty to not log. Optional.
   "hook-secret":"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", // GitHub webhook secret, used for automatic deployment. Only use type application/json hooks, and only the `push` event.
   "name":"ScratchVerifier", // Instance owner / ID. Included in the error message from the Discord webhook.
-  "admins":["user1", "user2"] // People with access to the /admin API's and /site/admin features.
+  "admins":["user1", "user2"] // LOWERCASE usernames of people with access to the /admin API's and /site/admin features.
 }

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -72,8 +72,7 @@
       "http": {
         "200 OK": "returns <a href=\"#verification-object\">Verification</a> object",
         "400 Bad Request": "username is invalid by Scratch rules",
-        "401 Unauthorized": "missing/invalid <a href=\"#authorization\">authorization</a>",
-        "404 Not Found": "username 404ed on Scratch API"
+        "401 Unauthorized": "missing/invalid <a href=\"#authorization\">authorization</a>"
       },
       "auth": true,
       "returns": {
@@ -121,8 +120,7 @@
       "http": {
         "204 No Content": "invalidation successful",
         "400 Bad Request": "username is invalid by Scratch rules",
-        "401 Unauthorized": "missing/invalid <a href=\"#authorization\">authorization</a>",
-        "404 Not Found": "username 404ed on Scratch API"
+        "401 Unauthorized": "missing/invalid <a href=\"#authorization\">authorization</a>"
       },
       "auth": true,
       "returns": null
@@ -150,7 +148,7 @@
       "http": {
         "200 OK": "returns <a href=\"#verification-object\">Verification</a> object",
         "400 Bad Request": "username is invalid by Scratch rules",
-        "404 Not Found": "username 404ed on Scratch API"
+        "403 Forbidden": "this username is banned from registering"
       },
       "returns": {
         "type": "Verification",
@@ -161,7 +159,7 @@
     {
       "type": "endpoint",
       "name": "Finish Logging In",
-      "desc": "Finish the process of logging in. Returns a <a href=\"#session-object\">Session</a> object on success.",
+      "desc": "Finish the process of logging in. If successful, response contains a <code>session</code> cookie that must be set for all endpoints listed after this one to work. Returns an <a href=\"#admin-object\">Admin</a> object on success.",
       "method": "POST",
       "path": "/users/{username}/finish-login",
       "params": {
@@ -172,14 +170,14 @@
         }
       },
       "http": {
-        "200 OK": "returns <a href=\"#session-object\">Session</a> object",
+        "200 OK": "returns <a href=\"#admin-object\">Admin</a> object",
         "400 Bad Request": "username is invalid by Scratch rules",
         "401 Unauthorized": "login failed",
         "404 Not Found": "username 404ed on Scratch API"
       },
       "returns": {
-        "type": "Session",
-        "session": 1234567890
+        "type": "Admin",
+        "admin": false
       }
     },
     {
@@ -193,20 +191,16 @@
           "type": "string",
           "desc": "The username to log out",
           "query": false
-        },
-        "session": {
-          "type": "integer",
-          "desc": "REQUIRED: Session ID returned by <a href=\"#finish-logging-in-endpoint\">Finish Logging In</a> endpoint",
-          "query": true
         }
       },
       "http": {
         "204 No Content": "successfully logged out",
         "400 Bad Request": "username is invalid by Scratch rules",
-        "401 Unauthorized": "<code>session</code> invalid or not specified",
+        "401 Unauthorized": "invalid or no <code>session</code> in cookies",
         "403 Forbidden": "username does not match session",
         "404 Not Found": "username 404ed on Scratch API"
       },
+      "auth": "finish-logging-in-endpoint",
       "returns": null
     },
     {
@@ -214,19 +208,14 @@
       "name": "Get Client Info",
       "desc": "Get your client ID, token, and username. Returns a <a href=\"#user-object\">User</a> object on success.",
       "method": "GET",
-      "path": "/session/{session ID}",
-      "params": {
-        "session ID": {
-          "type": "string",
-          "desc": "Session ID returned by <a href=\"#finish-logging-in-endpoint\">Finish Logging In</a> endpoint",
-          "query": false
-        }
-      },
+      "path": "/session",
+      "params": {},
       "http": {
         "200 OK": "returns <a href=\"#user-object\">User</a> object",
-        "401 Unauthorized": "<code>session ID</code> invalid or not specified",
+        "401 Unauthorized": "invalid or no <code>session</code> in cookies",
         "404 Not Found": "this user is not registered with the API yet"
       },
+      "auth": "finish-logging-in-endpoint",
       "returns": {
         "type": "User",
         "client_id": 10114764,
@@ -239,19 +228,14 @@
       "name": "Create Client",
       "desc": "If this user does not own a client yet, create and return one.",
       "method": "PUT",
-      "path": "/session/{session ID}",
-      "params": {
-        "session ID": {
-          "type": "string",
-          "desc": "Session ID returned by <a href=\"#finish-logging-in-endpoint\">Finish Logging In</a> endpoint",
-          "query": false
-        }
-      },
+      "path": "/session",
+      "params": {},
       "http": {
         "200 OK": "returns new <a href=\"#user-object\">User</a> object",
-        "401 Unauthorized": "<code>session ID</code> invalid or not specified",
+        "401 Unauthorized": "invalid or no <code>session</code> in cookies",
         "409 Conflict": "this user is already registered with the API"
       },
+      "auth": "finish-logging-in-endpoint",
       "returns": {
         "type": "User",
         "client_id": 10114764,
@@ -264,18 +248,13 @@
       "name": "Reset Token",
       "desc": "If you suspect that your token has been compromised, reset it through this endpoint.",
       "method": "PATCH",
-      "path": "/session/{session ID}",
-      "params": {
-        "session ID": {
-          "type": "string",
-          "desc": "Session ID returned by <a href=\"#finish-logging-in-endpoint\">Finish Logging In</a> endpoint",
-          "query": false
-        }
-      },
+      "path": "/session",
+      "params": {},
       "http": {
         "200 OK": "returns updated <a href=\"#user-object\">User</a> object",
-        "401 Unauthorized": "<code>session ID</code> invalid or not specified"
+        "401 Unauthorized": "invalid or no <code>session</code> in cookies"
       },
+      "auth": "finish-logging-in-endpoint",
       "returns": {
         "type": "User",
         "client_id": 10114764,
@@ -288,18 +267,13 @@
       "name": "Delete Client",
       "desc": "Deregister from the API. Returns 204 No Content on success.",
       "method": "DELETE",
-      "path": "/session/{session ID}",
-      "params": {
-        "session ID": {
-          "type": "string",
-          "desc": "Session ID returned by <a href=\"#finish-logging-in-endpoint\">Finish Logging In</a> endpoint",
-          "query": false
-        }
-      },
+      "path": "/session",
+      "params": {},
       "http": {
         "204 No Content": "client was successfully deleted",
-        "401 Unauthorized": "<code>session ID</code> invalid or not specified"
+        "401 Unauthorized": "invalid or no <code>session</code> in cookies"
       },
+      "auth": "finish-logging-in-endpoint",
       "returns": null
     },
     {
@@ -307,18 +281,13 @@
       "name": "Logout Session",
       "desc": "Invalidate this session ID.",
       "method": "POST",
-      "path": "/session/{session ID}/logout",
-      "params": {
-        "session ID": {
-          "type": "string",
-          "desc": "Session ID returned by <a href=\"#finish-logging-in-endpoint\">Finish Logging In</a> endpoint",
-          "query": false
-        }
-      },
+      "path": "/session/logout",
+      "params": {},
       "http": {
         "204 No Content": "successfully logged out",
-        "401 Unauthorized": "<code>session ID</code> invalid or not specified"
+        "401 Unauthorized": "invalid or no <code>session</code> in cookies"
       },
+      "auth": "finish-logging-in-endpoint",
       "returns": null
     },
     {
@@ -378,7 +347,7 @@
       },
       "http": {
         "200 OK": "returns list of <a href=\"#log-object\">Log</a> objects",
-        "400 Bad Request": "a query param was the wrong type",
+        "400 Bad Request": "<code>start</code> is after <code>end</code>, <code>before</code> is after <code>after</code>, <code>type</code> is invalid, or a query param was the wrong type",
         "403 Forbidden": "<code>limit</code> was greater than 500"
       },
       "returns": {
@@ -434,10 +403,10 @@
     },
     {
       "type": "object",
-      "name": "Session",
-      "desc": "Holds the session ID to use in other API registration endpoints.",
+      "name": "Admin",
+      "desc": "Indicates whether the user who just <a href=\"#finish-logging-in-endpoint\">finished logging in</a> is an admin on the site or not.",
       "fields": {
-        "session": {"type": "integer", "desc": "session ID to use"}
+        "admin": {"type": "boolean", "desc": "whether the user is an admin"}
       }
     },
     {
@@ -533,12 +502,12 @@
           "The API will send you a <a href=\"reference.html#verification-object\">Verification</a> object containing a code",
           "Post this code on your own profile comments",
           "Send an HTTP <span class=\"method\">POST</span> request to <code>/users/<span class=\"param\">{yourusername}</span>/finish-login</code>",
-          "You will receive a <a href=\"reference.html#session-object\">Session</a> object containing a single integer. This is your session ID; it lasts for a year",
-          "Assuming you haven't already created a client, send an HTTP <span class=\"method\">PUT</span> request to <code>/session/<span class=\"param\">{session}</span></code>",
+          "You will receive a cookie with your session ID. Set it; it lasts a year",
+          "Assuming you haven't already created a client, send an HTTP <span class=\"method\">PUT</span> request to <code>/session</code>",
           "You will receive a <a href=\"reference.html#user-object\">User</a> object containing your client ID and token",
           "Put your client ID and token into your app's configuration. Done!"
         ]},
-        "At any point, if it becomes necessary to fetch your info again, simply send an HTTP <span class=\"method\">GET</span> request to <code>/session/<span class=\"param\">{session}</span></code> and you will receive it. If you receive a 401 Unauthorized response, you need to get another session ID by following steps 1-5."
+        "At any point, if it becomes necessary to fetch your info again, simply send an HTTP <span class=\"method\">GET</span> request to <code>/session</code> and you will receive it. If you receive a 401 Unauthorized response, you need to get another session ID by following steps 1-5."
       ]
     },
     {
@@ -559,14 +528,14 @@
         ]},
         "Or using the API:",
         {"type": "ol", "items": [
-          "<span class=\"method\">GET</span> <code>/session/<span class=\"param\">{session}</span></code> to fetch your info",
+          "<span class=\"method\">GET</span> <code>/session</code> to fetch your info",
           "If you receive your info, skip to step 8. Otherwise, continue with step 3",
           "Send an HTTP <span class=\"method\">POST</span> request to <code>/users/<span class=\"param\">{yourusername}</span>/login</code>",
           "The API will send you a <a href=\"reference.html#verification-object\">Verification</a> object containing a code",
           "Post this code on your own profile comments",
           "Send an HTTP <span class=\"method\">POST</span> request to <code>/users/<span class=\"param\">{yourusername}</span>/finish-login</code>",
-          "You will receive a <a href=\"reference.html#session-object\">Session</a> object containing a single integer. This is your session ID; it lasts for a year",
-          "Send an HTTP <span class=\"method\">PATCH</span> request to <code>/session/<span class=\"param\">{session}</span></code>",
+          "You will receive a cookie with your session ID. Set it; it lasts a year",
+          "Send an HTTP <span class=\"method\">PATCH</span> request to <code>/session</code>",
           "You will receive a new <a href=\"reference.html#user-object\">User</a> object containing your client ID and updated token",
           "Update your token in your app's configuration. Done!"
         ]}
@@ -590,14 +559,14 @@
         ]},
         "Or using the API:",
         {"type": "ol", "items": [
-          "<span class=\"method\">GET</span> <code>/session/<span class=\"param\">{session}</span></code> to fetch your info",
+          "<span class=\"method\">GET</span> <code>/session</code> to fetch your info",
           "If you receive your info, skip to step 8. Otherwise, continue with step 3",
           "Send an HTTP <span class=\"method\">POST</span> request to <code>/users/<span class=\"param\">{yourusername}</span>/login</code>",
           "The API will send you a <a href=\"reference.html#verification-object\">Verification</a> object containing a code",
           "Post this code on your own profile comments",
           "Send an HTTP <span class=\"method\">POST</span> request to <code>/users/<span class=\"param\">{yourusername}</span>/finish-login</code>",
-          "You will receive a <a href=\"reference.html#session-object\">Session</a> object containing a single integer. This is your session ID; it lasts for a year",
-          "Send an HTTP <span class=\"method\">DELETE</span> request to <code>/session/<span class=\"param\">{session}</span></code>",
+          "You will receive a cookie with your session ID. Set it; it lasts a year",
+          "Send an HTTP <span class=\"method\">DELETE</span> request to <code>/session</code>",
           "You will receive a 204 No Content response. :("
         ]},
         "<i>Note: This only deregisters your client from the API. You are still free to re-register later. Resetting your token is almost like deregistering and re-registering again.</i>"

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -34,7 +34,7 @@
       "title": "API Reference",
       "paragraphs": [
         "The ScratchVerifier API is a HTTP/REST API for all operations.",
-        "<b>API Base URL</b>: <a href=\"http://scratchverifier.ddns.net:8888\">http://scratchverifier.ddns.net:8888</a>"
+        "<b>API Base URL</b>: <a href=\"https://scratchverifier.ddns.net\">https://scratchverifier.ddns.net</a>"
       ]
     },
     {
@@ -455,7 +455,7 @@
       "type": "section",
       "heading": "Basic Walkthrough",
       "paragraphs": [
-        "The API root URL is <a href=\"http://scratchverifier.ddns.net:8888\">http://scratchverifier.ddns.net:8888</a>",
+        "The API root URL is <a href=\"https://scratchverifier.ddns.net\">https://scratchverifier.ddns.net</a>",
         "After <a href=\"registration.html\"><b>registering</b></a>, here's how to use this API:",
         {"type": "ol", "items": [
           "Send an HTTP <span class=\"method\">PUT</span> request to <code>/verify/<span class=\"param\">{username}</span></code> with the client ID and token you obtained as HTTP Basic authorization",
@@ -477,7 +477,7 @@
       "type": "section",
       "heading": "Registering Through the Website",
       "paragraphs": [
-        "This is how to register with this API through the <a href=\"http://scratchverifier.ddns.net:8888/site/\">website</a>.",
+        "This is how to register with this API through the <a href=\"https://scratchverifier.ddns.net/site/\">website</a>.",
         {"type": "ol", "items": [
           "Visit the website.",
           "Click \"Login/Register\" at the top right",

--- a/docs/generate_docs.py
+++ b/docs/generate_docs.py
@@ -59,12 +59,14 @@ class Things:
                 continue
             path = path.replace('{%s}' % i, '<span class="param">{%s}</span>' % i)
         print('<div class="method-path{}" onclick="showOrHide(this)"><span \
-class="method">{}</span> <code>{}</code> <a href=\"#authorization\"><img \
+class="method">{}</span> <code>{}</code> <a href=\"#{}\"><img \
 src="https://image.flaticon.com/icons/png/512/61/61457.png" \
 title="Authorization necessary" /></a></div>'.format(
             " auth-needed" if 'auth' in thing else '',
             thing['method'],
-            path
+            path,
+            (thing['auth'] if thing['auth'] is not True
+             else 'authorization') if 'auth' in thing else 'authorization'
         ))
         print('<div style="display: none">')
         if has_param:
@@ -95,8 +97,8 @@ title="Authorization necessary" /></a></div>'.format(
         new_thing = {}
         new_thing['heading'] = 'Returns '
         if thing['returns']:
-            name = thing['returns']['type']
-            if thing['returns']['type'].endswith('[]'):
+            name = thing['returns'].get('__type__', thing['returns']['type'])
+            if name.endswith('[]'):
                 name = name[:-2]
                 new_thing['heading'] += 'a list of <a href=\"#{}-object\">\
 {}</a> objects'.format(name.lower(), name)
@@ -105,7 +107,10 @@ title="Authorization necessary" /></a></div>'.format(
 object'.format(
                     name.lower(), name
                 )
-            del thing['returns']['type']
+            if '__type__' in thing['returns']:
+                del thing['returns']['__type__']
+            else:
+                del thing['returns']['type']
             new_thing['text'] = json.dumps(thing['returns'], indent=2)
         else:
             new_thing['heading'] += 'nothing'

--- a/docs/reference.html
+++ b/docs/reference.html
@@ -99,7 +99,7 @@
 <tr><th>Status</th><th>Meaning</th>
 <tr><td>200 OK</td><td>returns <a href="#verification-object">Verification</a> object</td></tr>
 <tr><td>400 Bad Request</td><td>username is invalid by Scratch rules</td></tr>
-<tr><td>404 Not Found</td><td>username 404ed on Scratch API</td></tr>
+<tr><td>403 Forbidden</td><td>this username is banned from registering</td></tr>
 </table>
 <table><caption>Returns a <a href="#verification-object">Verification</a> object</caption>
 <tr><td class="pre">{
@@ -109,7 +109,7 @@
 </table>
 </div></div>
 <h3 id="finish-logging-in-endpoint">Finish Logging In Endpoint</h3>
-<p>Finish the process of logging in. Returns a <a href="#session-object">Session</a> object on success.</p>
+<p>Finish the process of logging in. If successful, response contains a <code>session</code> cookie that must be set for all endpoints listed after this one to work. Returns an <a href="#admin-object">Admin</a> object on success.</p>
 <div class="endpoint">
 <div class="method-path" onclick="showOrHide(this)"><span class="method">POST</span> <code>/users/<span class="param">{username}</span>/finish-login</code> <a href="#authorization"><img src="https://image.flaticon.com/icons/png/512/61/61457.png" title="Authorization necessary" /></a></div>
 <div style="display: none">
@@ -119,35 +119,31 @@
 </table>
 <table><caption>HTTP statuses</caption>
 <tr><th>Status</th><th>Meaning</th>
-<tr><td>200 OK</td><td>returns <a href="#session-object">Session</a> object</td></tr>
+<tr><td>200 OK</td><td>returns <a href="#admin-object">Admin</a> object</td></tr>
 <tr><td>400 Bad Request</td><td>username is invalid by Scratch rules</td></tr>
 <tr><td>401 Unauthorized</td><td>login failed</td></tr>
 <tr><td>404 Not Found</td><td>username 404ed on Scratch API</td></tr>
 </table>
-<table><caption>Returns a <a href="#session-object">Session</a> object</caption>
+<table><caption>Returns a <a href="#admin-object">Admin</a> object</caption>
 <tr><td class="pre">{
-  "session": 1234567890
+  "admin": false
 }</td></tr>
 </table>
 </div></div>
 <h3 id="logout-all-sessions-endpoint">Logout All Sessions Endpoint</h3>
 <p>Immediately invalidate all sessions under this username.</p>
 <div class="endpoint">
-<div class="method-path" onclick="showOrHide(this)"><span class="method">POST</span> <code>/users/<span class="param">{username}</span>/logout</code> <a href="#authorization"><img src="https://image.flaticon.com/icons/png/512/61/61457.png" title="Authorization necessary" /></a></div>
+<div class="method-path auth-needed" onclick="showOrHide(this)"><span class="method">POST</span> <code>/users/<span class="param">{username}</span>/logout</code> <a href="#finish-logging-in-endpoint"><img src="https://image.flaticon.com/icons/png/512/61/61457.png" title="Authorization necessary" /></a></div>
 <div style="display: none">
 <table><caption>URL Params</caption>
 <tr><th>Field</th><th>Type</th><th>Description</th>
 <tr><td>username</td><td>string</td><td>The username to log out</td></tr>
 </table>
-<table><caption>Query String Params</caption>
-<tr><th>Field</th><th>Type</th><th>Description</th>
-<tr><td>session</td><td>integer</td><td>REQUIRED: Session ID returned by <a href="#finish-logging-in-endpoint">Finish Logging In</a> endpoint</td></tr>
-</table>
 <table><caption>HTTP statuses</caption>
 <tr><th>Status</th><th>Meaning</th>
 <tr><td>204 No Content</td><td>successfully logged out</td></tr>
 <tr><td>400 Bad Request</td><td>username is invalid by Scratch rules</td></tr>
-<tr><td>401 Unauthorized</td><td><code>session</code> invalid or not specified</td></tr>
+<tr><td>401 Unauthorized</td><td>invalid or no <code>session</code> in cookies</td></tr>
 <tr><td>403 Forbidden</td><td>username does not match session</td></tr>
 <tr><td>404 Not Found</td><td>username 404ed on Scratch API</td></tr>
 </table>
@@ -158,16 +154,12 @@
 <h3 id="get-client-info-endpoint">Get Client Info Endpoint</h3>
 <p>Get your client ID, token, and username. Returns a <a href="#user-object">User</a> object on success.</p>
 <div class="endpoint">
-<div class="method-path" onclick="showOrHide(this)"><span class="method">GET</span> <code>/session/<span class="param">{session ID}</span></code> <a href="#authorization"><img src="https://image.flaticon.com/icons/png/512/61/61457.png" title="Authorization necessary" /></a></div>
+<div class="method-path auth-needed" onclick="showOrHide(this)"><span class="method">GET</span> <code>/session</code> <a href="#finish-logging-in-endpoint"><img src="https://image.flaticon.com/icons/png/512/61/61457.png" title="Authorization necessary" /></a></div>
 <div style="display: none">
-<table><caption>URL Params</caption>
-<tr><th>Field</th><th>Type</th><th>Description</th>
-<tr><td>session ID</td><td>string</td><td>Session ID returned by <a href="#finish-logging-in-endpoint">Finish Logging In</a> endpoint</td></tr>
-</table>
 <table><caption>HTTP statuses</caption>
 <tr><th>Status</th><th>Meaning</th>
 <tr><td>200 OK</td><td>returns <a href="#user-object">User</a> object</td></tr>
-<tr><td>401 Unauthorized</td><td><code>session ID</code> invalid or not specified</td></tr>
+<tr><td>401 Unauthorized</td><td>invalid or no <code>session</code> in cookies</td></tr>
 <tr><td>404 Not Found</td><td>this user is not registered with the API yet</td></tr>
 </table>
 <table><caption>Returns a <a href="#user-object">User</a> object</caption>
@@ -181,16 +173,12 @@
 <h3 id="create-client-endpoint">Create Client Endpoint</h3>
 <p>If this user does not own a client yet, create and return one.</p>
 <div class="endpoint">
-<div class="method-path" onclick="showOrHide(this)"><span class="method">PUT</span> <code>/session/<span class="param">{session ID}</span></code> <a href="#authorization"><img src="https://image.flaticon.com/icons/png/512/61/61457.png" title="Authorization necessary" /></a></div>
+<div class="method-path auth-needed" onclick="showOrHide(this)"><span class="method">PUT</span> <code>/session</code> <a href="#finish-logging-in-endpoint"><img src="https://image.flaticon.com/icons/png/512/61/61457.png" title="Authorization necessary" /></a></div>
 <div style="display: none">
-<table><caption>URL Params</caption>
-<tr><th>Field</th><th>Type</th><th>Description</th>
-<tr><td>session ID</td><td>string</td><td>Session ID returned by <a href="#finish-logging-in-endpoint">Finish Logging In</a> endpoint</td></tr>
-</table>
 <table><caption>HTTP statuses</caption>
 <tr><th>Status</th><th>Meaning</th>
 <tr><td>200 OK</td><td>returns new <a href="#user-object">User</a> object</td></tr>
-<tr><td>401 Unauthorized</td><td><code>session ID</code> invalid or not specified</td></tr>
+<tr><td>401 Unauthorized</td><td>invalid or no <code>session</code> in cookies</td></tr>
 <tr><td>409 Conflict</td><td>this user is already registered with the API</td></tr>
 </table>
 <table><caption>Returns a <a href="#user-object">User</a> object</caption>
@@ -204,16 +192,12 @@
 <h3 id="reset-token-endpoint">Reset Token Endpoint</h3>
 <p>If you suspect that your token has been compromised, reset it through this endpoint.</p>
 <div class="endpoint">
-<div class="method-path" onclick="showOrHide(this)"><span class="method">PATCH</span> <code>/session/<span class="param">{session ID}</span></code> <a href="#authorization"><img src="https://image.flaticon.com/icons/png/512/61/61457.png" title="Authorization necessary" /></a></div>
+<div class="method-path auth-needed" onclick="showOrHide(this)"><span class="method">PATCH</span> <code>/session</code> <a href="#finish-logging-in-endpoint"><img src="https://image.flaticon.com/icons/png/512/61/61457.png" title="Authorization necessary" /></a></div>
 <div style="display: none">
-<table><caption>URL Params</caption>
-<tr><th>Field</th><th>Type</th><th>Description</th>
-<tr><td>session ID</td><td>string</td><td>Session ID returned by <a href="#finish-logging-in-endpoint">Finish Logging In</a> endpoint</td></tr>
-</table>
 <table><caption>HTTP statuses</caption>
 <tr><th>Status</th><th>Meaning</th>
 <tr><td>200 OK</td><td>returns updated <a href="#user-object">User</a> object</td></tr>
-<tr><td>401 Unauthorized</td><td><code>session ID</code> invalid or not specified</td></tr>
+<tr><td>401 Unauthorized</td><td>invalid or no <code>session</code> in cookies</td></tr>
 </table>
 <table><caption>Returns a <a href="#user-object">User</a> object</caption>
 <tr><td class="pre">{
@@ -226,16 +210,12 @@
 <h3 id="delete-client-endpoint">Delete Client Endpoint</h3>
 <p>Deregister from the API. Returns 204 No Content on success.</p>
 <div class="endpoint">
-<div class="method-path" onclick="showOrHide(this)"><span class="method">DELETE</span> <code>/session/<span class="param">{session ID}</span></code> <a href="#authorization"><img src="https://image.flaticon.com/icons/png/512/61/61457.png" title="Authorization necessary" /></a></div>
+<div class="method-path auth-needed" onclick="showOrHide(this)"><span class="method">DELETE</span> <code>/session</code> <a href="#finish-logging-in-endpoint"><img src="https://image.flaticon.com/icons/png/512/61/61457.png" title="Authorization necessary" /></a></div>
 <div style="display: none">
-<table><caption>URL Params</caption>
-<tr><th>Field</th><th>Type</th><th>Description</th>
-<tr><td>session ID</td><td>string</td><td>Session ID returned by <a href="#finish-logging-in-endpoint">Finish Logging In</a> endpoint</td></tr>
-</table>
 <table><caption>HTTP statuses</caption>
 <tr><th>Status</th><th>Meaning</th>
 <tr><td>204 No Content</td><td>client was successfully deleted</td></tr>
-<tr><td>401 Unauthorized</td><td><code>session ID</code> invalid or not specified</td></tr>
+<tr><td>401 Unauthorized</td><td>invalid or no <code>session</code> in cookies</td></tr>
 </table>
 <table><caption>Returns nothing</caption>
 <tr><td class="pre"></td></tr>
@@ -244,16 +224,12 @@
 <h3 id="logout-session-endpoint">Logout Session Endpoint</h3>
 <p>Invalidate this session ID.</p>
 <div class="endpoint">
-<div class="method-path" onclick="showOrHide(this)"><span class="method">POST</span> <code>/session/<span class="param">{session ID}</span>/logout</code> <a href="#authorization"><img src="https://image.flaticon.com/icons/png/512/61/61457.png" title="Authorization necessary" /></a></div>
+<div class="method-path auth-needed" onclick="showOrHide(this)"><span class="method">POST</span> <code>/session/logout</code> <a href="#finish-logging-in-endpoint"><img src="https://image.flaticon.com/icons/png/512/61/61457.png" title="Authorization necessary" /></a></div>
 <div style="display: none">
-<table><caption>URL Params</caption>
-<tr><th>Field</th><th>Type</th><th>Description</th>
-<tr><td>session ID</td><td>string</td><td>Session ID returned by <a href="#finish-logging-in-endpoint">Finish Logging In</a> endpoint</td></tr>
-</table>
 <table><caption>HTTP statuses</caption>
 <tr><th>Status</th><th>Meaning</th>
 <tr><td>204 No Content</td><td>successfully logged out</td></tr>
-<tr><td>401 Unauthorized</td><td><code>session ID</code> invalid or not specified</td></tr>
+<tr><td>401 Unauthorized</td><td>invalid or no <code>session</code> in cookies</td></tr>
 </table>
 <table><caption>Returns nothing</caption>
 <tr><td class="pre"></td></tr>
@@ -283,7 +259,7 @@
 <table><caption>HTTP statuses</caption>
 <tr><th>Status</th><th>Meaning</th>
 <tr><td>200 OK</td><td>returns list of <a href="#log-object">Log</a> objects</td></tr>
-<tr><td>400 Bad Request</td><td>a query param was the wrong type</td></tr>
+<tr><td>400 Bad Request</td><td><code>start</code> is after <code>end</code>, <code>before</code> is after <code>after</code>, <code>type</code> is invalid, or a query param was the wrong type</td></tr>
 <tr><td>403 Forbidden</td><td><code>limit</code> was greater than 500</td></tr>
 </table>
 <table><caption>Returns a list of <a href="#log-object">Log</a> objects</caption>
@@ -330,12 +306,12 @@
 <tr><td>code</td><td>string</td><td>verification code to post</td></tr>
 <tr><td>username</td><td>string</td><td>username being verified</td></tr>
 </table>
-<h3 id="session-object">Session Object</h3>
-<p>Holds the session ID to use in other API registration endpoints.</p>
-<table><caption>Session Structure</caption>
+<h3 id="admin-object">Admin Object</h3>
+<p>Indicates whether the user who just <a href="#finish-logging-in-endpoint">finished logging in</a> is an admin on the site or not.</p>
+<table><caption>Admin Structure</caption>
 <tr><th>Field</th><th>Type</th><th>Description</th></tr>
 
-<tr><td>session</td><td>integer</td><td>session ID to use</td></tr>
+<tr><td>admin</td><td>boolean</td><td>whether the user is an admin</td></tr>
 </table>
 <h3 id="user-object">User Object</h3>
 <p>Holds data that a client needs to access the API.</p>
@@ -462,7 +438,7 @@
 </ul>
 </li>
 <li>
-<div><a href="#session-object">Session&nbsp;Object</a>
+<div><a href="#admin-object">Admin&nbsp;Object</a>
 <ul>
 </ul>
 </li>

--- a/docs/reference.html
+++ b/docs/reference.html
@@ -12,7 +12,7 @@
 
 <h1 id="api-reference">API Reference</h1>
 <p>The ScratchVerifier API is a HTTP/REST API for all operations.</p>
-<p><b>API Base URL</b>: <a href="http://scratchverifier.ddns.net:8888">http://scratchverifier.ddns.net:8888</a></p>
+<p><b>API Base URL</b>: <a href="https://scratchverifier.ddns.net">https://scratchverifier.ddns.net</a></p>
 <h2 id="authorization">Authorization</h2>
 <p>Authorization is done using <a href="https://tools.ietf.org/html/rfc7617">Basic HTTP Authorization</a>, using your client ID as the username and token as the password.</p>
 <table><caption>Example Authorization Header</caption>
@@ -34,7 +34,6 @@
 <tr><td>200 OK</td><td>returns <a href="#verification-object">Verification</a> object</td></tr>
 <tr><td>400 Bad Request</td><td>username is invalid by Scratch rules</td></tr>
 <tr><td>401 Unauthorized</td><td>missing/invalid <a href="#authorization">authorization</a></td></tr>
-<tr><td>404 Not Found</td><td>username 404ed on Scratch API</td></tr>
 </table>
 <table><caption>Returns a <a href="#verification-object">Verification</a> object</caption>
 <tr><td class="pre">{
@@ -78,7 +77,6 @@
 <tr><td>204 No Content</td><td>invalidation successful</td></tr>
 <tr><td>400 Bad Request</td><td>username is invalid by Scratch rules</td></tr>
 <tr><td>401 Unauthorized</td><td>missing/invalid <a href="#authorization">authorization</a></td></tr>
-<tr><td>404 Not Found</td><td>username 404ed on Scratch API</td></tr>
 </table>
 <table><caption>Returns nothing</caption>
 <tr><td class="pre"></td></tr>

--- a/docs/registration.html
+++ b/docs/registration.html
@@ -33,12 +33,12 @@
 <li>The API will send you a <a href="reference.html#verification-object">Verification</a> object containing a code</li>
 <li>Post this code on your own profile comments</li>
 <li>Send an HTTP <span class="method">POST</span> request to <code>/users/<span class="param">{yourusername}</span>/finish-login</code></li>
-<li>You will receive a <a href="reference.html#session-object">Session</a> object containing a single integer. This is your session ID; it lasts for a year</li>
-<li>Assuming you haven't already created a client, send an HTTP <span class="method">PUT</span> request to <code>/session/<span class="param">{session}</span></code></li>
+<li>You will receive a cookie with your session ID. Set it; it lasts a year</li>
+<li>Assuming you haven't already created a client, send an HTTP <span class="method">PUT</span> request to <code>/session</code></li>
 <li>You will receive a <a href="reference.html#user-object">User</a> object containing your client ID and token</li>
 <li>Put your client ID and token into your app's configuration. Done!</li>
 </ol>
-<p>At any point, if it becomes necessary to fetch your info again, simply send an HTTP <span class="method">GET</span> request to <code>/session/<span class="param">{session}</span></code> and you will receive it. If you receive a 401 Unauthorized response, you need to get another session ID by following steps 1-5.</p>
+<p>At any point, if it becomes necessary to fetch your info again, simply send an HTTP <span class="method">GET</span> request to <code>/session</code> and you will receive it. If you receive a 401 Unauthorized response, you need to get another session ID by following steps 1-5.</p>
 <h2 id="resetting-your-token">Resetting your Token</h2>
 <p>If you think your token has been compromised, you can reset your token using the website:</p>
 <ol>
@@ -54,14 +54,14 @@
 </ol>
 <p>Or using the API:</p>
 <ol>
-<li><span class="method">GET</span> <code>/session/<span class="param">{session}</span></code> to fetch your info</li>
+<li><span class="method">GET</span> <code>/session</code> to fetch your info</li>
 <li>If you receive your info, skip to step 8. Otherwise, continue with step 3</li>
 <li>Send an HTTP <span class="method">POST</span> request to <code>/users/<span class="param">{yourusername}</span>/login</code></li>
 <li>The API will send you a <a href="reference.html#verification-object">Verification</a> object containing a code</li>
 <li>Post this code on your own profile comments</li>
 <li>Send an HTTP <span class="method">POST</span> request to <code>/users/<span class="param">{yourusername}</span>/finish-login</code></li>
-<li>You will receive a <a href="reference.html#session-object">Session</a> object containing a single integer. This is your session ID; it lasts for a year</li>
-<li>Send an HTTP <span class="method">PATCH</span> request to <code>/session/<span class="param">{session}</span></code></li>
+<li>You will receive a cookie with your session ID. Set it; it lasts a year</li>
+<li>Send an HTTP <span class="method">PATCH</span> request to <code>/session</code></li>
 <li>You will receive a new <a href="reference.html#user-object">User</a> object containing your client ID and updated token</li>
 <li>Update your token in your app's configuration. Done!</li>
 </ol>
@@ -80,14 +80,14 @@
 </ol>
 <p>Or using the API:</p>
 <ol>
-<li><span class="method">GET</span> <code>/session/<span class="param">{session}</span></code> to fetch your info</li>
+<li><span class="method">GET</span> <code>/session</code> to fetch your info</li>
 <li>If you receive your info, skip to step 8. Otherwise, continue with step 3</li>
 <li>Send an HTTP <span class="method">POST</span> request to <code>/users/<span class="param">{yourusername}</span>/login</code></li>
 <li>The API will send you a <a href="reference.html#verification-object">Verification</a> object containing a code</li>
 <li>Post this code on your own profile comments</li>
 <li>Send an HTTP <span class="method">POST</span> request to <code>/users/<span class="param">{yourusername}</span>/finish-login</code></li>
-<li>You will receive a <a href="reference.html#session-object">Session</a> object containing a single integer. This is your session ID; it lasts for a year</li>
-<li>Send an HTTP <span class="method">DELETE</span> request to <code>/session/<span class="param">{session}</span></code></li>
+<li>You will receive a cookie with your session ID. Set it; it lasts a year</li>
+<li>Send an HTTP <span class="method">DELETE</span> request to <code>/session</code></li>
 <li>You will receive a 204 No Content response. :(</li>
 </ol>
 <p><i>Note: This only deregisters your client from the API. You are still free to re-register later. Resetting your token is almost like deregistering and re-registering again.</i></p>

--- a/docs/registration.html
+++ b/docs/registration.html
@@ -13,7 +13,7 @@
 <h1 id="scratchverifier-registration">ScratchVerifier Registration</h1>
 <p>This page contains walkthroughs for registering/handling your registration with this API.</p>
 <h2 id="registering-through-the-website">Registering Through the Website</h2>
-<p>This is how to register with this API through the <a href="http://scratchverifier.ddns.net:8888/site/">website</a>.</p>
+<p>This is how to register with this API through the <a href="https://scratchverifier.ddns.net/site/">website</a>.</p>
 <ol>
 <li>Visit the website.</li>
 <li>Click "Login/Register" at the top right</li>

--- a/docs/usage.html
+++ b/docs/usage.html
@@ -13,7 +13,7 @@
 <h1 id="scratchverifier-usage">ScratchVerifier Usage</h1>
 <p>This page contains a walkthrough for using this API.</p>
 <h2 id="basic-walkthrough">Basic Walkthrough</h2>
-<p>The API root URL is <a href="http://scratchverifier.ddns.net:8888">http://scratchverifier.ddns.net:8888</a></p>
+<p>The API root URL is <a href="https://scratchverifier.ddns.net">https://scratchverifier.ddns.net</a></p>
 <p>After <a href="registration.html"><b>registering</b></a>, here's how to use this API:</p>
 <ol>
 <li>Send an HTTP <span class="method">PUT</span> request to <code>/verify/<span class="param">{username}</span></code> with the client ID and token you obtained as HTTP Basic authorization</li>

--- a/public/admin/access_denied.html
+++ b/public/admin/access_denied.html
@@ -46,7 +46,7 @@
 		<h3 class="message">If you are an admin, please log onto the main website first. If you are not, this is not something you have to worry about.
 			<br>
 			<br>
-			<a href="">Return to Homepage</a>
+			<a href="/site">Return to Homepage</a>
 		</h3>
 	</body>
 </html>

--- a/public/admin/dashboard.html
+++ b/public/admin/dashboard.html
@@ -120,11 +120,9 @@
 			</div>
 			
 			<div class="logs">
-				<input type="text" class="logbox" id="AppID1" placeholder="App ID">
+				<input type="text" class="logbox" id="appid" placeholder="App ID">
 				<input type="text" class="logbox" id="username" placeholder="Username">
-				<input type="text" class="logbox" id="AppID2" placeholder="App ID">
-				<input type="text" class="logbox" id="before" placeholder="Before">
-				<input type="text" class="logbox" id="after" placeholder="After">
+				<input type="text" class="logbox" id="beforeafter" placeholder="Before-After">
 				<input type="text" class="logbox" id="startend" placeholder="Start-End">
 				<input type="text" class="logbox" id="limit" placeholder="Limit">
 				<button class="fetchbutton">Fetch</button>

--- a/public/admin/logs.html
+++ b/public/admin/logs.html
@@ -112,12 +112,50 @@
 		<header>
 			<h1 class="headertitle">ScratchVerifier Admin</h1>
 		</header>
-		<h2 class="title">Main Panel</h2>
+		<h2 class="title">Logs</h2>
 		<div class="content">
-			<div class="lookup">
-				<h3 style="margin-top: 0px;">Lookup Client By UID</h3>
-				<input type="text" placeholder="User ID" class="IDinput">
-				<button class="lookupbutton">Lookup</button>
+            <h5>Usage Logs</h5>
+			<div class="logs">
+				<input type="text" class="logbox" id="appid" placeholder="App ID">
+				<input type="text" class="logbox" id="username" placeholder="Username">
+				<input type="text" class="logbox" id="beforeafter" placeholder="Before-After">
+				<input type="text" class="logbox" id="startend" placeholder="Start-End">
+				<input type="text" class="logbox" id="limit" placeholder="Limit">
+				<button class="fetchbutton">Fetch</button>
+				<br>
+				<br>
+				<table class="logstable">
+					<tr>
+						<th>ID</th>
+						<th>Client ID</th>
+						<th>Username</th>
+						<th>Date</th>
+						<th>Log Type</th>
+                    </tr>
+                    <div style="display:inherit;margin:0;" id="logList"></div>
+				</table>
+            </div>
+            <br><br>
+            <h5>Audit Logs</h5>
+			<div class="logs">
+				<input type="text" class="logbox" id="username" placeholder="Username">
+				<input type="text" class="logbox" id="beforeafter" placeholder="Before-After">
+				<input type="text" class="logbox" id="startend" placeholder="Start-End">
+                <input type="text" class="logbox" id="limit" placeholder="Limit">
+                <select></select>
+				<button class="fetchbutton">Fetch</button>
+				<br>
+				<br>
+				<table class="logstable">
+					<tr>
+						<th>ID</th>
+						<th>Client ID</th>
+						<th>Username</th>
+						<th>Date</th>
+						<th>Log Type</th>
+                    </tr>
+                    <div style="display:inherit;margin:0;" id="logList"></div>
+				</table>
 			</div>
 		</div>
 	</body>

--- a/public/admin/user.html
+++ b/public/admin/user.html
@@ -3,7 +3,8 @@
 	<head>
 		<title>ScratchVerifier Admin</title>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
-		<link rel="shortcut icon" type="image/png" href="/site/resources/favicon.ico">
+        <link rel="shortcut icon" type="image/png" href="/site/resources/favicon.ico">
+        <script src="/resources/admincheck.js"></script>
 		<style>
 			* {
 			font-family: sans-serif;	

--- a/public/dashboard/index.html
+++ b/public/dashboard/index.html
@@ -67,7 +67,7 @@
   function logout(){
     document.querySelector("#dashboard").style.display = "none"
     document.querySelector(".loading").style.display = ""
-    fetch("/session/" + localStorage.getItem("token") + "/logout",{method:"POST"}).then(e=>{
+    fetch("/session/logout",{method:"POST"}).then(e=>{
       localStorage.removeItem('token');
       location.reload()
     })
@@ -76,7 +76,7 @@
     if (confirm("Log out all sessions?")){
       document.querySelector("#dashboard").style.display = "none"
       document.querySelector(".loading").style.display = ""
-      fetch("/users/" + window.username + "/logout?session=" + localStorage.getItem("token"),{method:"POST"}).then(e=>{
+      fetch("/users/" + window.username + "/logout",{method:"POST"}).then(e=>{
         localStorage.removeItem('token');
         location.reload()
       })
@@ -85,14 +85,14 @@
   function createApp(){
     document.querySelector("#createApp").style.display = "none"
     document.querySelector(".loading").style.display = ""
-    fetch("/session/" + localStorage.getItem("token"),{method:"PUT"}).then(e=>{
+    fetch("/session",{method:"PUT"}).then(e=>{
       window.onload()
     })
   }
   function regenerateToken(){
     document.querySelector("#dashboard").style.display = "none"
     document.querySelector(".loading").style.display = ""
-    fetch("/session/" + localStorage.getItem("token"),{method:"PATCH"}).then(e=>{
+    fetch("/session",{method:"PATCH"}).then(e=>{
       window.onload()
     })
   }
@@ -100,7 +100,7 @@
     if (confirm("Are you sure to delete this app?")){
       document.querySelector("#dashboard").style.display = "none"
       document.querySelector(".loading").style.display = ""
-      fetch("/session/" + localStorage.getItem("token"),{method:"DELETE"}).then(e=>{
+      fetch("/session",{method:"DELETE"}).then(e=>{
         window.onload()
       })
     }
@@ -110,7 +110,7 @@ window.onload = ()=>{
   if (typeof localStorage.getItem("token") !== "string"){
     location.replace("/site/login")
   } else {
-    fetch("/session/" + localStorage.getItem("token")).then(e=>{
+    fetch("/session").then(e=>{
       if (e.status === 401){
         localStorage.removeItem("token")
         location.replace("/site/login")

--- a/public/login/index.html
+++ b/public/login/index.html
@@ -98,7 +98,7 @@ function step2(){
     }
   }).then(data=>{
     if (typeof data === "object"){
-      localStorage.setItem("token",data.session)
+      localStorage.setItem("isAdmin",data.admin)
       location.replace("/site/dashboard")
     }
   })

--- a/public/resources/admincheck.js
+++ b/public/resources/admincheck.js
@@ -1,0 +1,6 @@
+document.onload = ()=>{
+    if (localStorage.getItem("isAdmin") !== "true"){
+        location.pathname = "/admin/access_denied.html"
+        document.write("Not Authorized")
+    }
+}

--- a/tests.py
+++ b/tests.py
@@ -9,41 +9,71 @@ from backend.responses import *
 API_ROOT = 'http://localhost:8888'
 session = requests.session()
 
+def set_session(session_id):
+    """Set session=session_id in cookies"""
+    # simply overwriting isn't enough, must unset before set
+    del session.cookies['session']
+    session.cookies['session'] = str(session_id)
+
 class TestApi(unittest.TestCase):
     """Test actual API endpoints."""
     def test_start(self):
         """Test PUT /verify/{}"""
+        # skip client_id-token auth
         session.post(API_ROOT + '/debug/1')
+        # start verification
         resp = session.put(API_ROOT + '/verify/Kenny2scratch')
-        self.assertEqual(resp.status_code, 200, 'not HTTP 200')
+        self.assertEqual(resp.status_code, 200, 'not HTTP 200 on success')
         resp = resp.json()
+
+        # response must implement structure
         self.assertIsInstance(resp, Verification, 'not Verification')
+        # usernames are casefolded
+        self.assertEqual(resp['username'], 'kenny2scratch', 'not casefolded')
+
+        # without finishing verification, the code should be cached
         code = resp['code']
         resp = session.put(API_ROOT + '/verify/Kenny2scratch').json()
         self.assertEqual(resp['code'], code, 'same PUT but not same code')
+
+        # regex-invalid names 400
         resp = session.put(API_ROOT + '/verify/Impossible Username')
         self.assertEqual(resp.status_code, 400, 'not HTTP 400 on invalid name')
+
+        # disable all auth bypass
         session.post(API_ROOT + '/debug/0')
+        # try verifying now
         resp = session.put(API_ROOT + '/verify/Kenny2scratch')
         self.assertEqual(resp.status_code, 401, 'not HTTP 401 on missing auth')
 
     def test_end(self):
         """Test POST /verify/{}"""
+        # skip client_id-token auth
+        # pretend verification code was posted
         session.post(API_ROOT + '/debug/3')
         session.put(API_ROOT + '/verify/Kenny2scratch')
+        # moment of truth: finish verification
         resp = session.post(API_ROOT + '/verify/Kenny2scratch')
         self.assertEqual(resp.status_code, 204, 'not HTTP 204 on success')
+
+        # continue skipping auth, but don't pretend verification
         session.post(API_ROOT + '/debug/1')
         session.put(API_ROOT + '/verify/Kenny2scratch')
+        # moment of truth: fail verification
         resp = session.post(API_ROOT + '/verify/Kenny2scratch')
         self.assertEqual(resp.status_code, 403, 'not HTTP 403 on failure')
+
+        # with no start, there is no end
         resp = session.post(API_ROOT + '/verify/Kenny2scratch')
         self.assertEqual(resp.status_code, 404, 'not HTTP 404 without start')
 
     def test_cancel(self):
         """Test DELETE /verify/{}"""
+        # skip client_id-token auth
         session.post(API_ROOT + '/debug/1')
+        # start verification...
         session.put(API_ROOT + '/verify/Kenny2scratch')
+        # ...then CANCEL it
         resp = session.delete(API_ROOT + '/verify/Kenny2scratch')
         self.assertEqual(resp.status_code, 204, 'not HTTP 204 on success')
 
@@ -51,112 +81,224 @@ class TestLogin(unittest.TestCase):
     """Test the login and registration flow."""
     def test_login(self):
         """Test POST /users/{}/login"""
-        session.post(API_ROOT + '/debug/1')
+        # turn off all backdoors just in case
+        session.post(API_ROOT + '/debug/0')
         resp = session.post(API_ROOT + '/users/Kenny2scratch/login')
-        self.assertEqual(resp.status_code, 200, 'not HTTP 200')
+        self.assertEqual(resp.status_code, 200, 'login start unsuccessful')
         resp = resp.json()
+        # response must implement structure
         self.assertIsInstance(resp, Verification, 'not Verification')
+
+        # regex-invalid names 400
         resp = session.post(API_ROOT + '/users/Impossible Username/login')
         self.assertEqual(resp.status_code, 400, 'not HTTP 400 on invalid name')
 
     def test_finish_login(self):
         """Test POST /users/{}/finish-login"""
-        session.post(API_ROOT + '/debug/3')
+        # pretend comment was posted
+        session.post(API_ROOT + '/debug/2')
         session.post(API_ROOT + '/users/Kenny2scratch/login')
         resp = session.post(API_ROOT + '/users/Kenny2scratch/finish-login')
-        self.assertEqual(resp.status_code, 200, 'not HTTP 200')
+        # successful login if comment was posted
+        self.assertEqual(resp.status_code, 200, 'login not successful')
+
         resp = resp.json()
-        self.assertIsInstance(resp, Session, 'not Session')
-        session.post(API_ROOT + '/debug/1')
+        # response must implement structure
+        self.assertIsInstance(resp, Admin, 'response was not Admin object')
+        # I'm an admin :)
+        self.assertTrue(resp['admin'], 'Kenny2scratch should be an admin')
+
+        # try that test again with non-admin
+        session.post(API_ROOT + '/users/Deathly_Hallows/login')
+        resp = session.post(API_ROOT + '/users/Deathly_Hallows/finish-login')
+        resp = resp.json()
+        self.assertFalse(resp['admin'], 'Deathly_Hallows should not be admin')
+
+        # stop pretending, this is the real world
+        session.post(API_ROOT + '/debug/0')
         session.post(API_ROOT + '/users/Kenny2scratch/login')
         resp = session.post(API_ROOT + '/users/Kenny2scratch/finish-login')
+        # failed login 401s
         self.assertEqual(resp.status_code, 401, 'not HTTP 401 on failure')
+
         resp = session.post(API_ROOT + '/users/Kenny2scratch/finish-login')
+        # unstarted login 404s
         self.assertEqual(resp.status_code, 404, 'not HTTP 404 without start')
 
     def test_get_client(self):
-        """Test GET /session/{}"""
+        """Test GET /session"""
+        # bypass real session checking
         session.post(API_ROOT + '/debug/1')
-        resp = session.get(API_ROOT + '/session/0')
+        # session=0 is a signal to the DB as well as the API
+        set_session(0)
+        resp = session.get(API_ROOT + '/session')
+        # successful get should be successful status
         self.assertEqual(resp.status_code, 200, 'not 200')
+
         resp = resp.json()
-        self.assertIsInstance(resp, User, 'not User')
-        resp = session.get(API_ROOT + '/session/1')
-        self.assertEqual(resp.status_code, 404, 'not 404 for unregistered client')
+        # response must implement structure
+        self.assertIsInstance(resp, User, 'response was not User object')
+
+        # session=-1 is guaranteed to be an invalid session ID,
+        # but we're still bypassing session checking...
+        set_session(-1)
+        resp = session.get(API_ROOT + '/session')
+        # ...so it's a valid session with no associated client
+        self.assertEqual(resp.status_code, 404, 'not 404 for no client')
+
+        # turn on session checking
         session.post(API_ROOT + '/debug/0')
-        resp = session.get(API_ROOT + '/session/1')
+        resp = session.get(API_ROOT + '/session') # session cookie is still -1
+        # now it realizes there's no session with that ID in the first place
         self.assertEqual(resp.status_code, 401, 'not 401 on missing auth')
 
     def test_put_client(self):
-        """Test PUT /session/{}"""
+        """Test PUT /session"""
+        # skip real session checking
         session.post(API_ROOT + '/debug/1')
-        resp = session.put(API_ROOT + '/session/1')
-        self.assertEqual(resp.status_code, 200, 'not 200')
+        # non-backdoor session ID, but checking is backdoored
+        set_session(1)
+        resp = session.put(API_ROOT + '/session')
+        self.assertEqual(resp.status_code, 200, 'real session ID still failed')
+
         resp = resp.json()
+        # response must implement structure
         self.assertIsInstance(resp, User, 'not User')
-        resp = session.put(API_ROOT + '/session/0')
+
+        # the backdoor session already has a dummy client registered,
+        set_session(0)
+        resp = session.put(API_ROOT + '/session')
+        # so it should conflict when trying to register a new one
         self.assertEqual(resp.status_code, 409, 'not 409 on existing client')
+
+        # turn real session checking back on
         session.post(API_ROOT + '/debug/0')
-        resp = session.put(API_ROOT + '/session/1')
+        set_session(1)
+        resp = session.put(API_ROOT + '/session')
         self.assertEqual(resp.status_code, 401, 'not 401 on missing auth')
 
     def test_patch_client(self):
-        """Test PATCH /session/{}"""
+        """Test PATCH /session"""
+        # bypass real session checking
         session.post(API_ROOT + '/debug/1')
-        resp = session.patch(API_ROOT + '/session/0')
-        self.assertEqual(resp.status_code, 200, 'not 200')
+        set_session(0)
+        # get previous token for later use
+        old_token = session.get(API_ROOT + '/session').json()['token']
+
+        resp = session.patch(API_ROOT + '/session')
+        # with a valid session, the response should be successful
+        self.assertEqual(resp.status_code, 200, 'PATCH was unsuccessful')
+
         resp = resp.json()
+        # response must implement structure
         self.assertIsInstance(resp, User, 'not User')
+        # the token should have been reset
+        self.assertNotEqual(resp['token'], old_token, 'token was not reset')
+
+        # ensure real session checking still works
         session.post(API_ROOT + '/debug/0')
-        resp = session.patch(API_ROOT + '/session/1')
+        set_session(1)
+        resp = session.patch(API_ROOT + '/session')
         self.assertEqual(resp.status_code, 401, 'not 401 on missing auth')
 
     def test_delete_client(self):
-        """Test DELETE /session/{}"""
+        """Test DELETE /session"""
+        # bypass real session checking
         session.post(API_ROOT + '/debug/1')
-        resp = session.delete(API_ROOT + '/session/0')
-        self.assertEqual(resp.status_code, 204, 'not 204 on success')
+        set_session(0)
+
+        resp = session.delete(API_ROOT + '/session')
+        # blank response
+        self.assertEqual(resp.status_code, 204, 'successful DELETE should 204')
+
+        # check real session checking
         session.post(API_ROOT + '/debug/0')
-        resp = session.delete(API_ROOT + '/session/1')
+        set_session(1)
+        resp = session.delete(API_ROOT + '/session')
         self.assertEqual(resp.status_code, 401, 'not 401 on missing auth')
+
+def do_dummy_actions():
+    """Do some stuff so that the logs are populated"""
+    # bypass auth and pretend verification works
+    session.post(API_ROOT + '/debug/3')
+    # add a start and successful verification
+    session.put(API_ROOT + '/verify/Kenny2scratch')
+    session.post(API_ROOT + '/verify/Kenny2scratch')
+
+    # no need to pretend verification works when it's being cancelled
+    session.post(API_ROOT + '/debug/1')
+    # add a start and cancelled verification
+    session.put(API_ROOT + '/verify/Kenny2scratch')
+    session.delete(API_ROOT + '/verify/Kenny2scratch')
 
 class TestLogging(unittest.TestCase):
     """Test logging-related endpoints."""
     def test_logs(self):
         """Test GET /usage"""
-        session.post(API_ROOT + '/debug/3')
-        session.put(API_ROOT + '/verify/Kenny2scratch')
-        session.post(API_ROOT + '/verify/Kenny2scratch')
-        session.post(API_ROOT + '/debug/1')
-        session.put(API_ROOT + '/verify/Kenny2scratch')
-        session.delete(API_ROOT + '/verify/Kenny2scratch')
+        do_dummy_actions()
+
+        # no need to pretend anything, logs are public
         session.post(API_ROOT + '/debug/0')
-        resp = session.get(API_ROOT + '/usage', params={'limit': 600})
-        self.assertEqual(resp.status_code, 403, 'not 403 on big limit')
+
         resp = session.get(API_ROOT + '/usage')
+        # a well-formed request should always be a 200
         self.assertEqual(resp.status_code, 200, 'not 200')
         resp = resp.json()
         self.assertIsInstance(resp, list, 'not a *list* of Logs')
+        # response items must implement structure
         self.assertIsInstance(resp[0], Log, 'not a list of *Log*s')
+
+        # match entries with previously actions
         self.assertEqual(resp[0]['log_type'], 4, 'last log was not invalidated')
         self.assertEqual(resp[0]['username'], 'kenny2scratch', 'wrong name')
         self.assertEqual(resp[1]['log_type'], 1, '2nd-last log was not started')
         self.assertEqual(resp[2]['log_type'], 2, '3rd-last log was not OK')
 
+    def test_important_log_params(self):
+        """Test GET /usage parameters"""
+        do_dummy_actions()
+        # debug not necessary for this
+        session.post(API_ROOT + '/debug/0')
+
+        # ensure quota exceeding fails
+        resp = session.get(API_ROOT + '/usage', params={'limit': 600})
+        self.assertEqual(resp.status_code, 403, 'not 403 on big limit')
+
+        # try limits
+        resp = session.get(API_ROOT + '/usage', params={'limit': 2}).json()
+        self.assertEqual(len(resp), 2, 'requested 2 entries but got sth else')
+
+        # try pagination
+        last_id = resp[-1]['log_id']
+        resp = session.get(API_ROOT + '/usage',
+                           params={'start': last_id}).json()
+        # next page should be before (in time) the last
+        self.assertGreater(last_id, resp[0]['log_id'],
+                           'first log before last is after it??')
+
     def test_log(self):
         """Test GET /usage/{}"""
-        session.post(API_ROOT + '/debug/1')
-        session.put(API_ROOT + '/verify/Kenny2scratch')
+        do_dummy_actions()
+        # debug not necessary
         session.post(API_ROOT + '/debug/0')
+
         resp = session.get(API_ROOT + '/usage/-1')
+        # no negative log IDs
         self.assertEqual(resp.status_code, 404, 'not 404 on nonexistent log')
+
+        # get specific log to fetch
         resp = session.get(API_ROOT + '/usage').json()
-        log_id = resp[-1]['log_id']
-        resp = session.get('%s/usage/%s' % (API_ROOT, log_id))
-        self.assertEqual(resp.status_code, 200, 'not 200')
+        log = resp[-1]
+
+        resp = session.get('%s/usage/%s' % (API_ROOT, log['log_id']))
+        # existent log should be success
+        self.assertEqual(resp.status_code, 200, 'existent log not 200')
+
         resp = resp.json()
-        self.assertIsInstance(resp, Log, 'not Log')
-        self.assertEqual(resp['log_type'], 1, 'wrong log type')
+        # response must implement structure
+        self.assertIsInstance(resp, Log, 'response was not Log object')
+        # check this is actually the same log
+        self.assertEqual(resp, log, 'wrong log type')
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests.py
+++ b/tests.py
@@ -22,7 +22,7 @@ class TestApi(unittest.TestCase):
         # skip client_id-token auth
         session.post(API_ROOT + '/debug/1')
         # start verification
-        resp = session.put(API_ROOT + '/verify/Kenny2scratch')
+        resp = session.put(API_ROOT + '/verify/kenny2scratch')
         self.assertEqual(resp.status_code, 200, 'not HTTP 200 on success')
         resp = resp.json()
 
@@ -33,7 +33,7 @@ class TestApi(unittest.TestCase):
 
         # without finishing verification, the code should be cached
         code = resp['code']
-        resp = session.put(API_ROOT + '/verify/Kenny2scratch').json()
+        resp = session.put(API_ROOT + '/verify/kenny2scratch').json()
         self.assertEqual(resp['code'], code, 'same PUT but not same code')
 
         # regex-invalid names 400
@@ -43,7 +43,7 @@ class TestApi(unittest.TestCase):
         # disable all auth bypass
         session.post(API_ROOT + '/debug/0')
         # try verifying now
-        resp = session.put(API_ROOT + '/verify/Kenny2scratch')
+        resp = session.put(API_ROOT + '/verify/kenny2scratch')
         self.assertEqual(resp.status_code, 401, 'not HTTP 401 on missing auth')
 
     def test_end(self):
@@ -51,20 +51,20 @@ class TestApi(unittest.TestCase):
         # skip client_id-token auth
         # pretend verification code was posted
         session.post(API_ROOT + '/debug/3')
-        session.put(API_ROOT + '/verify/Kenny2scratch')
+        session.put(API_ROOT + '/verify/kenny2scratch')
         # moment of truth: finish verification
-        resp = session.post(API_ROOT + '/verify/Kenny2scratch')
+        resp = session.post(API_ROOT + '/verify/kenny2scratch')
         self.assertEqual(resp.status_code, 204, 'not HTTP 204 on success')
 
         # continue skipping auth, but don't pretend verification
         session.post(API_ROOT + '/debug/1')
-        session.put(API_ROOT + '/verify/Kenny2scratch')
+        session.put(API_ROOT + '/verify/kenny2scratch')
         # moment of truth: fail verification
-        resp = session.post(API_ROOT + '/verify/Kenny2scratch')
+        resp = session.post(API_ROOT + '/verify/kenny2scratch')
         self.assertEqual(resp.status_code, 403, 'not HTTP 403 on failure')
 
         # with no start, there is no end
-        resp = session.post(API_ROOT + '/verify/Kenny2scratch')
+        resp = session.post(API_ROOT + '/verify/kenny2scratch')
         self.assertEqual(resp.status_code, 404, 'not HTTP 404 without start')
 
     def test_cancel(self):
@@ -72,9 +72,9 @@ class TestApi(unittest.TestCase):
         # skip client_id-token auth
         session.post(API_ROOT + '/debug/1')
         # start verification...
-        session.put(API_ROOT + '/verify/Kenny2scratch')
+        session.put(API_ROOT + '/verify/kenny2scratch')
         # ...then CANCEL it
-        resp = session.delete(API_ROOT + '/verify/Kenny2scratch')
+        resp = session.delete(API_ROOT + '/verify/kenny2scratch')
         self.assertEqual(resp.status_code, 204, 'not HTTP 204 on success')
 
 class TestLogin(unittest.TestCase):
@@ -83,7 +83,7 @@ class TestLogin(unittest.TestCase):
         """Test POST /users/{}/login"""
         # turn off all backdoors just in case
         session.post(API_ROOT + '/debug/0')
-        resp = session.post(API_ROOT + '/users/Kenny2scratch/login')
+        resp = session.post(API_ROOT + '/users/kenny2scratch/login')
         self.assertEqual(resp.status_code, 200, 'login start unsuccessful')
         resp = resp.json()
         # response must implement structure
@@ -97,8 +97,8 @@ class TestLogin(unittest.TestCase):
         """Test POST /users/{}/finish-login"""
         # pretend comment was posted
         session.post(API_ROOT + '/debug/2')
-        session.post(API_ROOT + '/users/Kenny2scratch/login')
-        resp = session.post(API_ROOT + '/users/Kenny2scratch/finish-login')
+        session.post(API_ROOT + '/users/kenny2scratch/login')
+        resp = session.post(API_ROOT + '/users/kenny2scratch/finish-login')
         # successful login if comment was posted
         self.assertEqual(resp.status_code, 200, 'login not successful')
 
@@ -106,7 +106,7 @@ class TestLogin(unittest.TestCase):
         # response must implement structure
         self.assertIsInstance(resp, Admin, 'response was not Admin object')
         # I'm an admin :)
-        self.assertTrue(resp['admin'], 'Kenny2scratch should be an admin')
+        self.assertTrue(resp['admin'], 'kenny2scratch should be an admin')
 
         # try that test again with non-admin
         session.post(API_ROOT + '/users/Deathly_Hallows/login')
@@ -116,12 +116,12 @@ class TestLogin(unittest.TestCase):
 
         # stop pretending, this is the real world
         session.post(API_ROOT + '/debug/0')
-        session.post(API_ROOT + '/users/Kenny2scratch/login')
-        resp = session.post(API_ROOT + '/users/Kenny2scratch/finish-login')
+        session.post(API_ROOT + '/users/kenny2scratch/login')
+        resp = session.post(API_ROOT + '/users/kenny2scratch/finish-login')
         # failed login 401s
         self.assertEqual(resp.status_code, 401, 'not HTTP 401 on failure')
 
-        resp = session.post(API_ROOT + '/users/Kenny2scratch/finish-login')
+        resp = session.post(API_ROOT + '/users/kenny2scratch/finish-login')
         # unstarted login 404s
         self.assertEqual(resp.status_code, 404, 'not HTTP 404 without start')
 
@@ -222,14 +222,14 @@ def do_dummy_actions():
     # bypass auth and pretend verification works
     session.post(API_ROOT + '/debug/3')
     # add a start and successful verification
-    session.put(API_ROOT + '/verify/Kenny2scratch')
-    session.post(API_ROOT + '/verify/Kenny2scratch')
+    session.put(API_ROOT + '/verify/kenny2scratch')
+    session.post(API_ROOT + '/verify/kenny2scratch')
 
     # no need to pretend verification works when it's being cancelled
     session.post(API_ROOT + '/debug/1')
     # add a start and cancelled verification
-    session.put(API_ROOT + '/verify/Kenny2scratch')
-    session.delete(API_ROOT + '/verify/Kenny2scratch')
+    session.put(API_ROOT + '/verify/kenny2scratch')
+    session.delete(API_ROOT + '/verify/kenny2scratch')
 
 class TestLogging(unittest.TestCase):
     """Test logging-related endpoints."""


### PR DESCRIPTION
- Change previous URL parameter-based session system for registration endpoints to cookie-based system
- Add ratelimits and admin API endpoints to set them
- Add bans and admin API endpoints to use them
- Add an admin API endpoint to get client info for better context
- Change documented API root because SSL works now! (Previous root still works for backwards compatibility but it is not recommended because you'll be sending your token in the clear.)